### PR TITLE
Add control the number of categorical levels to be displayed in histograms

### DIFF
--- a/facets_overview/python/base_feature_statistics_generator.py
+++ b/facets_overview/python/base_feature_statistics_generator.py
@@ -39,7 +39,8 @@ class BaseFeatureStatisticsGenerator(BaseGenericFeatureStatisticsGenerator):
                              max_entries=10000,
                              features=None,
                              is_sequence=False,
-                             iterator_options=None):
+                             iterator_options=None,
+                             histogram_categorical_levels_count=None):
     """Creates a feature statistics proto from a set of TFRecord files.
 
     Args:
@@ -58,6 +59,10 @@ class BaseFeatureStatisticsGenerator(BaseGenericFeatureStatisticsGenerator):
           False if tf.Examples. Defaults to false.
       iterator_options: Options to pass to the iterator that reads the examples.
           Defaults to None.
+      histogram_categorical_levels_count: int, controls the maximum number of
+          levels to display in histograms for categorical features.
+          Useful to prevent codes/IDs features from bloating the stats object.
+          Defaults to None.
 
     Returns:
       The feature statistics proto for the provided files.
@@ -67,7 +72,10 @@ class BaseFeatureStatisticsGenerator(BaseGenericFeatureStatisticsGenerator):
       entries, size = self._GetTfRecordEntries(entry['path'], max_entries,
                                                is_sequence, iterator_options)
       datasets.append({'entries': entries, 'size': size, 'name': entry['name']})
-    return self.GetDatasetsProto(datasets, features)
+    return self.GetDatasetsProto(
+      datasets,
+      features,
+      histogram_categorical_levels_count)
 
   def _ParseExample(self, example_features, example_feature_lists, entries,
                     index):

--- a/facets_overview/python/base_generic_feature_statistics_generator.py
+++ b/facets_overview/python/base_generic_feature_statistics_generator.py
@@ -29,7 +29,7 @@ class BaseGenericFeatureStatisticsGenerator(object):
     self.datasets_proto = datasets_proto
     self.histogram_proto = histogram_proto
 
-  def ProtoFromDataFrames(self, dataframes):
+  def ProtoFromDataFrames(self, dataframes, histogram_categorical_levels_count=None):
     """Creates a feature statistics proto from a set of pandas dataframes.
 
     Args:
@@ -37,7 +37,9 @@ class BaseGenericFeatureStatisticsGenerator(object):
           proto. Each entry contains a 'table' field of the dataframe of the
             data
           and a 'name' field to identify the dataset in the proto.
-
+      histogram_categorical_levels_count: int, controls the maximum number of levels
+          to display in histograms for categorical features. Useful to prevent codes/IDs
+          features from bloating the stats object. Defaults to None.
     Returns:
       The feature statistics proto for the provided tables.
     """
@@ -52,7 +54,7 @@ class BaseGenericFeatureStatisticsGenerator(object):
           'size': len(table),
           'name': dataframe['name']
       })
-    return self.GetDatasetsProto(datasets)
+    return self.GetDatasetsProto(datasets, histogram_categorical_levels_count=histogram_categorical_levels_count)
 
   def DtypeToType(self, dtype):
     """Converts a Numpy dtype to the FeatureNameStatistics.Type proto enum."""
@@ -138,7 +140,7 @@ class BaseGenericFeatureStatisticsGenerator(object):
         'type': data_type
     }
 
-  def GetDatasetsProto(self, datasets, features=None):
+  def GetDatasetsProto(self, datasets, features=None, histogram_categorical_levels_count=None):
     """Generates the feature stats proto from dictionaries of feature values.
 
     Args:
@@ -151,6 +153,9 @@ class BaseGenericFeatureStatisticsGenerator(object):
           feature statistics for. If set to None then all features in the
             dataset
           are analyzed. Defaults to None.
+      histogram_categorical_levels_count: int, controls the maximum number of levels
+          to display in histograms for categorical features. Useful to prevent codes/IDs
+          features from bloating the stats object. Defaults to None.
 
     Returns:
       The feature statistics proto for the provided datasets.
@@ -253,7 +258,7 @@ class BaseGenericFeatureStatisticsGenerator(object):
               featstats.avg_length = np.mean(np.vectorize(len)(strs))
               vals, counts = np.unique(strs, return_counts=True)
               featstats.unique = len(vals)
-              sorted_vals = sorted(zip(counts, vals), reverse=True)
+              sorted_vals = sorted(zip(counts, vals), reverse=True)[:histogram_categorical_levels_count]
               for val_index, val in enumerate(sorted_vals):
                 if val[1].dtype.type is np.str_:
                   printable_val = val[1]

--- a/facets_overview/python/base_generic_feature_statistics_generator.py
+++ b/facets_overview/python/base_generic_feature_statistics_generator.py
@@ -29,7 +29,8 @@ class BaseGenericFeatureStatisticsGenerator(object):
     self.datasets_proto = datasets_proto
     self.histogram_proto = histogram_proto
 
-  def ProtoFromDataFrames(self, dataframes, histogram_categorical_levels_count=None):
+  def ProtoFromDataFrames(self, dataframes,
+                          histogram_categorical_levels_count=None):
     """Creates a feature statistics proto from a set of pandas dataframes.
 
     Args:
@@ -37,9 +38,10 @@ class BaseGenericFeatureStatisticsGenerator(object):
           proto. Each entry contains a 'table' field of the dataframe of the
             data
           and a 'name' field to identify the dataset in the proto.
-      histogram_categorical_levels_count: int, controls the maximum number of levels
-          to display in histograms for categorical features. Useful to prevent codes/IDs
-          features from bloating the stats object. Defaults to None.
+      histogram_categorical_levels_count: int, controls the maximum number of
+          levels to display in histograms for categorical features.
+          Useful to prevent codes/IDs features from bloating the stats object.
+          Defaults to None.
     Returns:
       The feature statistics proto for the provided tables.
     """
@@ -54,7 +56,9 @@ class BaseGenericFeatureStatisticsGenerator(object):
           'size': len(table),
           'name': dataframe['name']
       })
-    return self.GetDatasetsProto(datasets, histogram_categorical_levels_count=histogram_categorical_levels_count)
+    return self.GetDatasetsProto(
+      datasets,
+      histogram_categorical_levels_count=histogram_categorical_levels_count)
 
   def DtypeToType(self, dtype):
     """Converts a Numpy dtype to the FeatureNameStatistics.Type proto enum."""
@@ -140,7 +144,8 @@ class BaseGenericFeatureStatisticsGenerator(object):
         'type': data_type
     }
 
-  def GetDatasetsProto(self, datasets, features=None, histogram_categorical_levels_count=None):
+  def GetDatasetsProto(self, datasets, features=None,
+                       histogram_categorical_levels_count=None):
     """Generates the feature stats proto from dictionaries of feature values.
 
     Args:
@@ -153,9 +158,10 @@ class BaseGenericFeatureStatisticsGenerator(object):
           feature statistics for. If set to None then all features in the
             dataset
           are analyzed. Defaults to None.
-      histogram_categorical_levels_count: int, controls the maximum number of levels
-          to display in histograms for categorical features. Useful to prevent codes/IDs
-          features from bloating the stats object. Defaults to None.
+      histogram_categorical_levels_count: int, controls the maximum number of
+          levels to display in histograms for categorical features.
+          Useful to prevent codes/IDs features from bloating the stats object.
+          Defaults to None.
 
     Returns:
       The feature statistics proto for the provided datasets.
@@ -258,7 +264,8 @@ class BaseGenericFeatureStatisticsGenerator(object):
               featstats.avg_length = np.mean(np.vectorize(len)(strs))
               vals, counts = np.unique(strs, return_counts=True)
               featstats.unique = len(vals)
-              sorted_vals = sorted(zip(counts, vals), reverse=True)[:histogram_categorical_levels_count]
+              sorted_vals = sorted(zip(counts, vals), reverse=True)
+              sorted_vals = sorted_vals[:histogram_categorical_levels_count]
               for val_index, val in enumerate(sorted_vals):
                 if val[1].dtype.type is np.str_:
                   printable_val = val[1]


### PR DESCRIPTION
Allow the user to limit the number of categorical levels to display in histograms.
https://github.com/PAIR-code/facets/issues/55