### PR TITLE
Fix scrolling speed and rendering issue.

### DIFF
--- a/facets_overview/components/facets_overview_chart/facets-overview-chart.ts
+++ b/facets_overview/components/facets_overview_chart/facets-overview-chart.ts
@@ -690,51 +690,60 @@ Polymer({
           plot.foreground() as d3.Selection<HTMLElement, {}, null, undefined>);
       this._updateSelectionVisibility(this.selection);
 
-      // Setup Interaction.Pointer for tooltip and attach to the plot.
-      this._onPointer = new Plottable.Interactions.Pointer();
-      this._onPointerEnterFunction = (p: any) => {
-        // For line charts, give a tooltip for the closest point on any line.
-        // For other charts, give a tooltip for all entries in any dataset
-        // that is overlapping with the datum nearest the pointer (for
-        // overlapping histograms for example).
-        const entities = getEntities(p);
-        if (entities.length > 0) {
-          const title =
-              entities
-                  .map(entity => {
-                    return (entity.dataset.metadata().name == null ||
-                            this.dataModel.getDatasetNames().length === 1) ?
-                        tooltipCallback(entity.datum) :
-                        entity.dataset.metadata().name + ': ' +
-                            tooltipCallback(entity.datum);
-                  })
-                  .join('\n');
-          tooltip.text(title);
-          tooltip.style("opacity", "1");
-        }
-      };
-      this._onPointer.onPointerMove(this._onPointerEnterFunction);
-      this._onPointerExitFunction = function(p: {}) {
-        tooltip.style("opacity", "0");
-      };
-      this._onPointer.onPointerExit(this._onPointerExitFunction);
-      this._onPointer.attachTo(plot);
-
-      if (this.chartSelection !== utils.CHART_SELECTION_LIST_QUANTILES) {
-        this._onClick = new Plottable.Interactions.Click();;
-        const self = this;
-        this._onClickFunction = (p: any) => {
-          const entities = getEntities(p);
-          if (entities.length > 0) {
-            selectionPositioner(self._selectionElem, entities[0]);
-            const selection: utils.FeatureSelection|null =
-                selectionCallback(entities[0].datum);
-            self._setSelection(selection);
-          }
-        };
-        this._onClick.onClick(this._onClickFunction);
-        this._onClick.attachTo(plot);
-      }
+      chartSelection
+          .on('mouseenter',
+              () => {
+                // Setup Interaction.Pointer for tooltip and attach to the plot.
+                this._onPointer = new Plottable.Interactions.Pointer();
+                this._onPointerEnterFunction = (p: any) => {
+                  // For line charts, give a tooltip for the closest point on
+                  // any line. For other charts, give a tooltip for all entries
+                  // in any dataset that is overlapping with the datum nearest
+                  // the pointer (for overlapping histograms for example).
+                  const entities = getEntities(p);
+                  if (entities.length > 0) {
+                    const title =
+                        entities
+                            .map(entity => {
+                              return (entity.dataset.metadata().name == null ||
+                                      this.dataModel.getDatasetNames()
+                                              .length === 1) ?
+                                  tooltipCallback(entity.datum) :
+                                  entity.dataset.metadata().name + ': ' +
+                                      tooltipCallback(entity.datum);
+                            })
+                            .join('\n');
+                    tooltip.text(title);
+                    tooltip.style('opacity', '1');
+                  }
+                };
+                this._onPointer.onPointerMove(this._onPointerEnterFunction);
+                this._onPointerExitFunction = function(p: {}) {
+                  tooltip.style('opacity', '0');
+                };
+                this._onPointer.onPointerExit(this._onPointerExitFunction);
+                this._onPointer.attachTo(plot);
+                if (this.chartSelection !==
+                    utils.CHART_SELECTION_LIST_QUANTILES) {
+                  this._onClick = new Plottable.Interactions.Click();
+                  const self = this;
+                  this._onClickFunction = (p: any) => {
+                    const entities = getEntities(p);
+                    if (entities.length > 0) {
+                      selectionPositioner(self._selectionElem, entities[0]);
+                      const selection: utils.FeatureSelection|null =
+                          selectionCallback(entities[0].datum);
+                      self._setSelection(selection);
+                    }
+                  };
+                  this._onClick.onClick(this._onClickFunction);
+                  this._onClick.attachTo(plot);
+                }
+              })
+          .on('mouseleave', () => {
+            this._onPointer.detachFrom(plot);
+            this._onClick.detachFrom(plot);
+          });
 
       // Add padding equal to the Y axis component to the X axis table to align
       // the axes.

--- a/facets_overview/components/facets_overview_table/facets-overview-table.html
+++ b/facets_overview/components/facets_overview_table/facets-overview-table.html
@@ -56,7 +56,12 @@ limitations under the License.
         border-right: solid 0.5px rgba(0,0,0,0.1);
         padding-left: 8px;
       }
-      .table-row {
+      .numeric-row {
+        min-height: 80px;
+        display: table-row;
+      }
+      .categorical-row {
+        min-height: 98px;
         display: table-row;
       }
       .table-cell {
@@ -143,7 +148,7 @@ limitations under the License.
                  as="feature"
                  class="feature-iron-list">
         <template>
-          <div class="table-row">
+          <div class$="[[_getTableRowClass(numeric)]]">
             <div class="table-cell">
               <div class="feature-name">[[_getFeatureName(feature)]]</div>
               <template is="dom-repeat" items="[[_getDatasets(dataModel)]]" as="dataset" index-as="datasetIndex">

--- a/facets_overview/components/facets_overview_table/facets-overview-table.ts
+++ b/facets_overview/components/facets_overview_table/facets-overview-table.ts
@@ -191,5 +191,8 @@ Polymer({
   },
   _getTableWrapperClass(features: FeatureNameStatistics[]) {
     return !features || features.length === 0 ? 'hidden' : '';
+  },
+  _getTableRowClass(numeric: boolean) {
+    return numeric ? 'numeric-row' : 'categorical-row';
   }
 });


### PR DESCRIPTION
Only set plottable interaction objects on charts when mouse is inside a chart area.
This stops many of these objects being on many charts from causing scrolling issues due to constant calculations by plottable.

Also set a min height for table elements to avoid iron-list rendering issue on long lists where rows get bunched together.