### PR TITLE
Add BytesStatistics information to table for BYTES features.

### DIFF
--- a/facets_overview/common/utils.ts
+++ b/facets_overview/common/utils.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import BytesStatistics from 'goog:proto.featureStatistics.BytesStatistics';
 import CommonStatistics from 'goog:proto.featureStatistics.CommonStatistics';
 import CustomStatistic from 'goog:proto.featureStatistics.CustomStatistic';
 import DatasetFeatureStatisticsList from 'goog:proto.featureStatistics.DatasetFeatureStatisticsList';
@@ -1265,6 +1266,25 @@ function getStringStatsEntries(
 }
 
 /**
+ * Gets the CssFormattedStrings for a bytes feature's stats for display in the
+ * table.
+ */
+function getBytesStatsEntries(bytesstats: BytesStatistics|null) {
+  const entries: CssFormattedString[] = [];
+  if (bytesstats) {
+    entries.push(formatIntWithClass(bytesstats.getUnique()));
+    entries.push(formatStringWithClass('-'));
+    entries.push(formatStringWithClass('-'));
+    entries.push(formatFloatWithClass(bytesstats.getAvgNumBytes()));
+  } else {
+    for (let i = 0; i < 4; i++) {
+      entries.push(formatStringWithClass('-'));
+    }
+  }
+  return entries;
+}
+
+/**
  * Gets the CssFormattedStrings for a feature's custom stats for display in the
  * table.
  */
@@ -1324,9 +1344,12 @@ export function getStatsEntries(
   if (stats.getNumStats()) {
     entries = entries.concat(
         getNumStatsEntries(stats.getNumStats(), commonStats, showWeighted));
-  } else {
+  } else if (stats.getStringStats()) {
     entries = entries.concat(
         getStringStatsEntries(stats.getStringStats(), showWeighted));
+  } else {
+    entries = entries.concat(
+        getBytesStatsEntries(stats.getBytesStats()));
   }
 
   // Add the entry for the custom stats if the dataset has custom stats.

--- a/facets_overview/functional_tests/single/single_test.ts
+++ b/facets_overview/functional_tests/single/single_test.ts
@@ -16,6 +16,8 @@
  */
 import DatasetFeatureStatisticsList from 'goog:proto.featureStatistics.DatasetFeatureStatisticsList';
 import FeatureNameStatistics from 'goog:proto.featureStatistics.FeatureNameStatistics';
+import BytesStatistics from 'goog:proto.featureStatistics.BytesStatistics';
+import CommonStatistics from 'goog:proto.featureStatistics.CommonStatistics';
 import Histogram from 'goog:proto.featureStatistics.Histogram';
 import { DataPoint, generateStats } from '../../common/feature_statistics_generator';
 import { FeatureSelection } from '../../common/utils';
@@ -58,6 +60,26 @@ function create(): DatasetFeatureStatisticsList {
                      'both-infs': d3.randomNormal(5)()});
   }
   const stats = generateStats(dataPoints);
+
+  // Add a BYTES feature.
+  const bs = new BytesStatistics();
+  const cs = new CommonStatistics();
+  cs.setNumMissing(0);
+  cs.setNumNonMissing(20);
+  cs.setMinNumValues(1);
+  cs.setMaxNumValues(1);
+  cs.setAvgNumValues(1);
+  bs.setCommonStats(cs);
+  bs.setUnique(19);
+  bs.setAvgNumBytes(500)
+  bs.setMinNumBytes(250);
+  bs.setMaxNumBytes(1000);
+  const f = new FeatureNameStatistics();
+  f.setName('encodedImageBytes');
+  f.setType(FeatureNameStatistics.Type.BYTES);
+  f.setBytesStats(bs);
+  stats.getFeaturesList().push(f);
+
   stats.setName('train');
   data.getDatasetsList().push(stats);
   return data;

--- a/facets_overview/functional_tests/single/single_test.ts
+++ b/facets_overview/functional_tests/single/single_test.ts
@@ -14,10 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import DatasetFeatureStatisticsList from 'goog:proto.featureStatistics.DatasetFeatureStatisticsList';
-import FeatureNameStatistics from 'goog:proto.featureStatistics.FeatureNameStatistics';
 import BytesStatistics from 'goog:proto.featureStatistics.BytesStatistics';
 import CommonStatistics from 'goog:proto.featureStatistics.CommonStatistics';
+import DatasetFeatureStatisticsList from 'goog:proto.featureStatistics.DatasetFeatureStatisticsList';
+import FeatureNameStatistics from 'goog:proto.featureStatistics.FeatureNameStatistics';
 import Histogram from 'goog:proto.featureStatistics.Histogram';
 import { DataPoint, generateStats } from '../../common/feature_statistics_generator';
 import { FeatureSelection } from '../../common/utils';


### PR DESCRIPTION
As requested, add num unique and average length fields from BytesStatistics to the categorical table for features of type BYTES.