### PR TITLE
Only import required typography file.

### DIFF
--- a/facets_dive/components/facets_dive_info_card/facets-dive-info-card.html
+++ b/facets_dive/components/facets_dive_info_card/facets-dive-info-card.html
@@ -16,7 +16,7 @@ limitations under the License.
 -->
 <link rel="import" href="../../../polymer/polymer.html">
 <link rel="import" href="../../../paper-card/paper-card.html">
-<link rel="import" href="../../../paper-styles/paper-styles.html">
+<link rel="import" href="../../../paper-styles/typography.html">
 <link rel="import" href="../../lib/info-renderers.html">
 
 <dom-module id='facets-dive-info-card'>


### PR DESCRIPTION
This fixes a deprecated warning in the browser console as paper-styles.html makes use of deprecated polymer code and is unneeded by this component anyways.