### PR TITLE
Adding item multi-select

### DIFF
--- a/facets_dive/components/facets_dive/facets-dive.html
+++ b/facets_dive/components/facets_dive/facets-dive.html
@@ -133,6 +133,7 @@ limitations under the License.
           item-positioning-vertical-label-color="{{itemPositioningVerticalLabelColor}}"
           item-positioning-horizontal-label-color="{{itemPositioningHorizontalLabelColor}}"
           selected-data="{{selectedData}}"
+          selected-indices="{{selectedIndices}}"
         ></facets-dive-vis>
 
       <facets-dive-controls

--- a/facets_dive/components/facets_dive/facets-dive.ts
+++ b/facets_dive/components/facets_dive/facets-dive.ts
@@ -330,10 +330,9 @@ Polymer({
       notify: true,
     },
     selectedIndices: {
-      type: Object,
-      value: {},
+      type: Array,
+      value: [],
       notify: true,
-      observer: '_selectedIndicesChanged',
     },
     height: {
       type: Number,
@@ -343,12 +342,6 @@ Polymer({
     infoRenderer: {
       type: Object,  // Function.
     },
-  },
-
-  _selectedIndicesChanged(indicesDict: vis.IndexDict) {
-    const indices =
-        Object.keys(indicesDict).map((indexStr: string) => +indexStr);
-    this.fire('new-selected-indices', {indices});
   },
 
   ready(this: any) {

--- a/facets_dive/components/facets_dive/facets-dive.ts
+++ b/facets_dive/components/facets_dive/facets-dive.ts
@@ -329,6 +329,12 @@ Polymer({
       value: [],
       notify: true,
     },
+    selectedIndices: {
+      type: Object,
+      value: {},
+      notify: true,
+      observer: '_selectedIndicesChanged',
+    },
     height: {
       type: Number,
       value: null,
@@ -337,6 +343,12 @@ Polymer({
     infoRenderer: {
       type: Object,  // Function.
     },
+  },
+
+  _selectedIndicesChanged(indicesDict: vis.IndexDict) {
+    const indices =
+        Object.keys(indicesDict).map((indexStr: string) => +indexStr);
+    this.fire('new-selected-indices', {indices});
   },
 
   ready(this: any) {

--- a/facets_dive/components/facets_dive_vis/facets-dive-vis.ts
+++ b/facets_dive/components/facets_dive_vis/facets-dive-vis.ts
@@ -417,11 +417,6 @@ interface FacetingInfo {
 }
 
 /**
- * A dictionary of booleans that is used to hold a set of data indices.
- */
-export type IndexDict = {[index: string]: boolean};
-
-/**
  * External interface for the <facets-dive-vis> Polymer element.
  */
 export interface FacetsDiveVis extends Element {
@@ -578,10 +573,9 @@ export interface FacetsDiveVis extends Element {
   selectedData: Array<{}>;
 
   /**
-   * Dict of indices of currently selected objects. Should all be elements of
-   * the data array.
+   * Indices of currently selected objects from the data array.
    */
-  selectedIndices: IndexDict;
+  selectedIndices: number[];
 
   /**
    * Polymer setter for attribute values.
@@ -862,24 +856,17 @@ class FacetsDiveVizInternal {
     const x = this.camera.position.x + mouseX / this.scale;
     const y = this.camera.position.y - mouseY / this.scale;
     const spriteIndexes = this.spriteMesh.findSprites(x, y);
-    const selectedIndices: IndexDict= {};
-    if (event.ctrlKey) {
-      for (const key in this.elem.selectedIndices) {
-        if (this.elem.selectedIndices.hasOwnProperty(key)) {
-          selectedIndices[key] = true;
-        }
-      }
-    }
+    const selectedIndicesSet = event.ctrlKey ?
+		new Set(this.elem.selectedIndices) : new Set();
     for (let i = 0; i < spriteIndexes.length; i++) {
-      selectedIndices[spriteIndexes[i]] = true;
+      selectedIndicesSet.add(spriteIndexes[i]);
     }
-    const selectedIndicesList = Object.keys(selectedIndices);
-    const selectedData = new Array(selectedIndicesList.length);
-    for (let i = 0; i < selectedIndicesList.length; i++) {
-      selectedData[i] = this.elem.data[selectedIndicesList[i]];
+    this.elem.set('selectedIndices', Array.from(selectedIndicesSet));
+    const selectedData = [];
+    for (let i = 0; i < this.elem.selectedIndices.length; i++) {
+      selectedData.push(this.elem.data[this.elem.selectedIndices[i]]);
     }
     this.elem.set('selectedData', selectedData);
-    this.elem.set('selectedIndices', selectedIndices);
   }
 
   /**

--- a/facets_dive/components/facets_dive_vis/facets-dive-vis.ts
+++ b/facets_dive/components/facets_dive_vis/facets-dive-vis.ts
@@ -417,6 +417,11 @@ interface FacetingInfo {
 }
 
 /**
+ * A dictionary of booleans that is used to hold a set of data indices.
+ */
+export type IndexDict = {[index: string]: boolean};
+
+/**
  * External interface for the <facets-dive-vis> Polymer element.
  */
 export interface FacetsDiveVis extends Element {
@@ -571,6 +576,12 @@ export interface FacetsDiveVis extends Element {
    * Currently selected objects. Should all be elements of the data array.
    */
   selectedData: Array<{}>;
+
+  /**
+   * Dict of indices of currently selected objects. Should all be elements of
+   * the data array.
+   */
+  selectedIndices: IndexDict;
 
   /**
    * Polymer setter for attribute values.
@@ -851,11 +862,24 @@ class FacetsDiveVizInternal {
     const x = this.camera.position.x + mouseX / this.scale;
     const y = this.camera.position.y - mouseY / this.scale;
     const spriteIndexes = this.spriteMesh.findSprites(x, y);
-    const selectedData = new Array(spriteIndexes.length);
+    const selectedIndices: IndexDict= {};
+    if (event.ctrlKey) {
+      for (const key in this.elem.selectedIndices) {
+        if (this.elem.selectedIndices.hasOwnProperty(key)) {
+          selectedIndices[key] = true;
+        }
+      }
+    }
     for (let i = 0; i < spriteIndexes.length; i++) {
-      selectedData[i] = this.elem.data[spriteIndexes[i]];
+      selectedIndices[spriteIndexes[i]] = true;
+    }
+    const selectedIndicesList = Object.keys(selectedIndices);
+    const selectedData = new Array(selectedIndicesList.length);
+    for (let i = 0; i < selectedIndicesList.length; i++) {
+      selectedData[i] = this.elem.data[selectedIndicesList[i]];
     }
     this.elem.set('selectedData', selectedData);
+    this.elem.set('selectedIndices', selectedIndices);
   }
 
   /**
@@ -2888,6 +2912,11 @@ Polymer({
       observer: '_updateColors',
     },
     selectedData: {
+      type: Array,
+      value: [],
+      notify: true,
+    },
+    selectedIndices: {
       type: Array,
       value: [],
       notify: true,

--- a/facets_dive/demo/quickdraw.ts
+++ b/facets_dive/demo/quickdraw.ts
@@ -18,6 +18,9 @@ import {FacetsDive} from '../components/facets-dive/facets-dive';
 
 const ss = document.querySelector('facets-dive') as FacetsDive;
 
+ss.addEventListener('new-selected-indices',
+	(e: CustomEvent) => console.log(e.detail));
+
 const loadDataset = (url: string) => {
   d3.json(`${url}.json`, (data: Array<{}>) => {
     ss.data = data;

--- a/facets_dive/demo/quickdraw.ts
+++ b/facets_dive/demo/quickdraw.ts
@@ -18,9 +18,6 @@ import {FacetsDive} from '../components/facets-dive/facets-dive';
 
 const ss = document.querySelector('facets-dive') as FacetsDive;
 
-ss.addEventListener('new-selected-indices',
-	(e: CustomEvent) => console.log(e.detail));
-
 const loadDataset = (url: string) => {
   d3.json(`${url}.json`, (data: Array<{}>) => {
     ss.data = data;


### PR DESCRIPTION
Allows control-click to select more than one item in Dive.
Sends custom event to clients when selection changes, indicating the data
indices of all selected items.