### PR TITLE
Update deprecated @apply and var() CSS syntax for Polymer 2.0

### DIFF
--- a/facets_dive/components/facets_dive_controls/facets-dive-controls.html
+++ b/facets_dive/components/facets_dive_controls/facets-dive-controls.html
@@ -35,7 +35,7 @@ limitations under the License.
   <template>
     <style>
       :host {
-        @apply(--paper-font-common-base);
+        @apply --paper-font-common-base;
 
         box-sizing: border-box;
         display: flex;
@@ -184,7 +184,7 @@ limitations under the License.
       }
 
       .legend h2 {
-        @apply(--paper-font-subhead);
+        @apply --paper-font-subhead;
         color: #4f423e;
         font-weight: bold;
         line-height: 1;

--- a/facets_dive/components/facets_dive_info_card/facets-dive-info-card.html
+++ b/facets_dive/components/facets_dive_info_card/facets-dive-info-card.html
@@ -23,7 +23,7 @@ limitations under the License.
   <template>
     <style>
       :host {
-        @apply(--paper-font-common-base);
+        @apply --paper-font-common-base;
         box-sizing: border-box;
         max-height: 100%;
         max-width: 100%;
@@ -35,7 +35,7 @@ limitations under the License.
         font-size: 14px;
       }
       ::content dd {
-        @apply(--paper-font-common-code);
+        @apply --paper-font-common-code;
         color: #513726;
         margin: 0 0 16px 0;
       }

--- a/facets_dive/components/facets_dive_vis/facets-dive-vis.html
+++ b/facets_dive/components/facets_dive_vis/facets-dive-vis.html
@@ -39,8 +39,8 @@ limitations under the License.
         width: 100%;
       }
       ::content .labels {
-        @apply(--paper-font-common-base);
-        @apply(--paper-font-headline);
+        @apply --paper-font-common-base;
+        @apply --paper-font-headline;
       }
     </style>
     <!-- Additional content filled in dynamically. -->


### PR DESCRIPTION
Polymer 2.0 is production ready, and we advise all projects to begin migration.

This change migrates uses of @apply to remove the deprecated parentheses syntax, and adds var() to use of CSS Custom Properties in the fallback position of a var() expression.

These changes are backwards-compatible with Polymer 1.0 applications, as well as browser-native implementations of CSS Custom Properties.