### PR TITLE
replaces Array.map() with a loop

### DIFF
--- a/facets_overview/components/facets_overview_chart/facets-overview-chart.ts
+++ b/facets_overview/components/facets_overview_chart/facets-overview-chart.ts
@@ -604,9 +604,9 @@ Polymer({
           return ret;
         });
     this._tableData = utils.getValueAndCountsArray(chartDataPercs);
-    chartDataPercs.map(
-        (d: utils.BucketsForDataset, i: number) => lines.addDataset(
-            new Plottable.Dataset(d.percBuckets, {name: d.name})));
+    for (const d of chartDataPercs) {
+      lines.addDataset(new Plottable.Dataset(d.percBuckets, {name: d.name}));
+    }
 
     // Set the X and Y coordinates of each point in the line based on the
     // ratios calculated above and set the line color.


### PR DESCRIPTION
Array.map() creates and returns a new array which is unused.
This pattern will become a compilation error soon in google3. We're enabling a check in google's internal TypeScript compiler that detects calls to well-known functions and methods that return a value that is discarded.