### PR TITLE
fixing display issues

### DIFF
--- a/facets_overview/common/test/utils_test.ts
+++ b/facets_overview/common/test/utils_test.ts
@@ -1641,32 +1641,28 @@ describe('formatPercentageWithClass', () => {
 
 describe('getLegendEntries', () => {
   it('handles numeric features', () => {
-    const entries = utils.getLegendEntries(
-      FeatureNameStatistics.Type.INT, false, false);
+    const entries = utils.getLegendEntries(true, false, false);
     expect(entries.length).to.equal(8);
     expect(entries[0].cssClass).to.equal('');
     expect(entries[3].cssClass).to.equal('');
   });
 
   it('handles string features', () => {
-    const entries = utils.getLegendEntries(
-      FeatureNameStatistics.Type.STRING, false, false);
+    const entries = utils.getLegendEntries(false, false, false);
     expect(entries.length).to.equal(6);
     expect(entries[0].cssClass).to.equal('');
     expect(entries[3].cssClass).to.equal('');
   });
 
   it('handles custom stats', () => {
-    const entries = utils.getLegendEntries(
-      FeatureNameStatistics.Type.INT, false, true);
+    const entries = utils.getLegendEntries(true, false, true);
     expect(entries.length).to.equal(9);
     expect(entries[0].cssClass).to.equal('');
     expect(entries[8].cssClass).to.equal('data-custom ');
   });
 
   it('handles weighted stats', () => {
-    const entries = utils.getLegendEntries(
-      FeatureNameStatistics.Type.INT, true, false);
+    const entries = utils.getLegendEntries(true, true, false);
     expect(entries.length).to.equal(8);
     expect(entries[0].cssClass).to.equal('');
     expect(entries[3].cssClass).to.equal('data-weighted ');
@@ -1690,8 +1686,7 @@ describe('getStatsEntries', () => {
     c.setNumMissing(3);
     c.setNumNonMissing(17);
     c.setAvgNumValues(1);
-    const entries = utils.getStatsEntries(
-      FeatureNameStatistics.Type.INT, f, false, false);
+    const entries = utils.getStatsEntries(f, false, false);
     expect(entries.length).to.equal(8);
     expect(entries[0].str).to.equal('17');
     expect(entries[1].str).to.equal('15%');
@@ -1714,8 +1709,7 @@ describe('getStatsEntries', () => {
     c.setNumMissing(3);
     c.setNumNonMissing(17);
     c.setAvgNumValues(1);
-    const entries = utils.getStatsEntries(
-      FeatureNameStatistics.Type.STRING, f, false, false);
+    const entries = utils.getStatsEntries(f, false, false);
     expect(entries.length).to.equal(6);
     expect(entries[0].str).to.equal('17');
     expect(entries[1].str).to.equal('15%');
@@ -1736,8 +1730,7 @@ describe('getStatsEntries', () => {
     c.setNumMissing(3);
     c.setNumNonMissing(17);
     c.setAvgNumValues(1);
-    const entries = utils.getStatsEntries(
-      FeatureNameStatistics.Type.STRING, f, false, false);
+    const entries = utils.getStatsEntries(f, false, false);
     expect(entries.length).to.equal(6);
     expect(entries[3].str).to.equal('-');
     expect(entries[4].str).to.equal('-');
@@ -1751,8 +1744,7 @@ describe('getStatsEntries', () => {
     custom.setName('cust');
     custom.setStr('hi');
     f.setCustomStatsList([custom]);
-    const entries = utils.getStatsEntries(
-      FeatureNameStatistics.Type.INT, f, false, true);
+    const entries = utils.getStatsEntries(f, false, true);
     expect(entries.length).to.equal(9);
     expect(entries[8].str).to.equal('cust: hi');
     expect(entries[8].cssClass).to.equal('data-custom ');
@@ -1762,8 +1754,7 @@ describe('getStatsEntries', () => {
     const f = new FeatureNameStatistics();
     f.setType(FeatureNameStatistics.Type.INT);
     f.setNumStats(new NumericStatistics());
-    const entries = utils.getStatsEntries(
-      FeatureNameStatistics.Type.INT, f, false, true);
+    const entries = utils.getStatsEntries(f, false, true);
     expect(entries.length).to.equal(9);
     expect(entries[8].str).to.equal('-');
     expect(entries[8].cssClass).to.equal('data-custom ');
@@ -1776,8 +1767,7 @@ describe('getStatsEntries', () => {
     const custom = new CustomStatistic();
     custom.setName('cust');
     f.setCustomStatsList([custom]);
-    const entries = utils.getStatsEntries(
-      FeatureNameStatistics.Type.INT, f, false, true);
+    const entries = utils.getStatsEntries(f, false, true);
     expect(entries.length).to.equal(9);
     expect(entries[8].str).to.equal('cust: 0');
     expect(entries[8].cssClass).to.equal('data-custom ');
@@ -1801,8 +1791,7 @@ describe('getStatsEntries', () => {
     n.setCommonStats(c);
     c.setNumMissing(3);
     c.setNumNonMissing(10);
-    const entries = utils.getStatsEntries(
-      FeatureNameStatistics.Type.INT, f, true, false);
+    const entries = utils.getStatsEntries(f, true, false);
     expect(entries.length).to.equal(8);
     expect(entries[0].cssClass).to.equal('');
     expect(entries[3].cssClass).to.equal('data-weighted ');
@@ -1811,8 +1800,7 @@ describe('getStatsEntries', () => {
   it('handles missing stats', () => {
     const f = new FeatureNameStatistics();
     f.setType(FeatureNameStatistics.Type.STRING);
-    const entries = utils.getStatsEntries(
-      FeatureNameStatistics.Type.STRING, f, false, false);
+    const entries = utils.getStatsEntries(f, false, false);
     expect(entries.length).to.equal(6);
     expect(entries[0].str).to.equal('0');
     expect(entries[1].str).to.equal('100%');

--- a/facets_overview/common/utils.ts
+++ b/facets_overview/common/utils.ts
@@ -1129,13 +1129,12 @@ function getClassForCssFormattedString(
 }
 
 export function getLegendEntries(
-    type: FeatureNameStatistics.Type, showWeighted: boolean,
+    numeric: boolean, showWeighted: boolean,
     hasCustom: boolean): CssFormattedString[] {
   const entries: CssFormattedString[] = [];
   entries.push(formatStringWithClass('count'));
   entries.push(formatStringWithClass('missing'));
-  if (type === FeatureNameStatistics.Type.INT ||
-      type === FeatureNameStatistics.Type.FLOAT) {
+  if (numeric) {
     entries.push(formatStringWithClass('mean', showWeighted));
     entries.push(formatStringWithClass('std dev', showWeighted));
     entries.push(formatStringWithClass('zeros'));
@@ -1326,7 +1325,7 @@ function getCustomStatsEntries(stats: CustomStatistic[]|null) {
  * Gets the CssFormattedStrings for a feature's stats for display in the table.
  */
 export function getStatsEntries(
-    type: FeatureNameStatistics.Type, stats: FeatureNameStatistics,
+    stats: FeatureNameStatistics,
     showWeighted: boolean, hasCustom: boolean): CssFormattedString[] {
   let commonStats: CommonStatistics|null = null;
 

--- a/facets_overview/components/facets_overview_chart/facets-overview-chart.html
+++ b/facets_overview/components/facets_overview_chart/facets-overview-chart.html
@@ -67,10 +67,18 @@ limitations under the License.
         clear: left;
       }
       .label-cell {
-        width: 100px;
-        max-width: 100px;
-        min-width: 100px;
+        width: 90px;
+        max-width: 90px;
+        min-width: 90px;
         overflow-wrap: break-word;
+      }
+      .non-overflow-label-cell {
+        width: 90px;
+        max-width: 90px;
+        min-width: 90px;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
       }
       .count-cell {
         width: 100px;
@@ -129,7 +137,9 @@ limitations under the License.
           <div class="dialog-header-row">
             <div class="dialog-row-entry table-header label-cell">Value</div>
             <template is="dom-repeat" items="[[data]]" as="data">
-              <div class="dialog-row-entry table-header label-cell">[[data.name]]</div>
+              <div class="dialog-row-entry table-header">
+                <div class="non-overflow-label-cell">[[data.name]]</div>
+              </div>
             </template>
           </div>
           <iron-list items="[[_tableData]]" as="entry" class$="[[_tableDataClass]]">

--- a/facets_overview/components/facets_overview_row_legend/facets-overview-row-legend.ts
+++ b/facets_overview/components/facets_overview_row_legend/facets-overview-row-legend.ts
@@ -21,17 +21,17 @@ Polymer({
   is: 'facets-overview-row-legend',
 
   properties: {
-    type: Object,
+    numeric: Boolean,
     showWeighted: Boolean,
     hasCustom: Boolean,
     dataModel: Object,
     _entries: {
       type: Array,
-      computed: '_getEntries(type, showWeighted, hasCustom)'
+      computed: '_getEntries(numeric, showWeighted, hasCustom)'
     },
   },
-  _getEntries: function(type: FeatureNameStatistics.Type, showWeighted: boolean,
+  _getEntries: function(numeric: boolean, showWeighted: boolean,
                         hasCustom: boolean) {
-    return utils.getLegendEntries(type, showWeighted, hasCustom);
+    return utils.getLegendEntries(numeric, showWeighted, hasCustom);
   },
 });

--- a/facets_overview/components/facets_overview_row_stats/facets-overview-row-stats.ts
+++ b/facets_overview/components/facets_overview_row_stats/facets-overview-row-stats.ts
@@ -23,7 +23,6 @@ Polymer({
   is: 'facets-overview-row-stats',
 
   properties: {
-    type: Object,
     stats: Object,
     showWeighted: Boolean,
     hasCustom: Boolean,
@@ -32,14 +31,14 @@ Polymer({
     compareMode: Boolean,
     _entries: {
       type: Array,
-      computed: '_getEntries(type, stats, showWeighted, hasCustom)'
+      computed: '_getEntries(stats, showWeighted, hasCustom)'
     },
   },
   observers: ['_colorLegendBox(dataModel, datasetIndex, compareMode)'],
   _getEntries: function(
-      type: FeatureNameStatistics.Type, stats: FeatureNameStatistics,
+      stats: FeatureNameStatistics,
       showWeighted: boolean, hasCustom: boolean) {
-    return utils.getStatsEntries(type, stats, showWeighted, hasCustom);
+    return utils.getStatsEntries(stats, showWeighted, hasCustom);
   },
   _colorLegendBox: function(
       this: any, dataModel: OverviewDataModel, datasetIndex: number,

--- a/facets_overview/components/facets_overview_table/facets-overview-table.html
+++ b/facets_overview/components/facets_overview_table/facets-overview-table.html
@@ -116,7 +116,7 @@ limitations under the License.
         <div class="header-cell table-cell">
           <div class="table-name">[[_getTitle(numeric)]] Features ([[_getFeatureCountText(dataModel, numeric, features)]])
           </div>
-          <facets-overview-row-legend type="[[_getFeatureTypeForList(features)]]"
+          <facets-overview-row-legend numeric="[[numeric]]"
                                 show-weighted="[[_showWeighted]]"
                                 has-custom="[[_hasCustomStats(dataModel)]]"
                                 data-model="[[dataModel]]">
@@ -153,7 +153,7 @@ limitations under the License.
               <div class="feature-name">[[_getFeatureName(feature)]]</div>
               <template is="dom-repeat" items="[[_getDatasets(dataModel)]]" as="dataset" index-as="datasetIndex">
                 <div>
-                  <facets-overview-row-stats type="[[_getFeatureType(feature)]]"
+                  <facets-overview-row-stats
                                        stats="[[_getStats(dataModel, dataset, feature)]]"
                                        custom-stats="[[_getAllCustomStats(dataModel, feature)]]"
                                        show-weighted="[[_showWeighted]]"

--- a/facets_overview/components/facets_overview_table/facets-overview-table.ts
+++ b/facets_overview/components/facets_overview_table/facets-overview-table.ts
@@ -83,16 +83,6 @@ Polymer({
   _getFeatureName(feature: FeatureNameStatistics) {
     return feature.getName();
   },
-  // tslint:disable-next-line:no-any typescript/polymer temporary issue
-  _getFeatureType(this: any, feature: FeatureNameStatistics) {
-    return this._getFeatureTypeForList([feature]);
-  },
-  _getFeatureTypeForList(features: FeatureNameStatistics[]) {
-    // If value is missing then assume INT, which is the 0-index enum.
-    return features.length > 0 ?
-        features[0].getType() || FeatureNameStatistics.Type.INT :
-        FeatureNameStatistics.Type.INT;
-  },
   _hasCustomStats(dataModel: OverviewDataModel) {
     if (dataModel == null) {
       return false;
@@ -171,16 +161,6 @@ Polymer({
     }
     return utils.hasWeightedHistogram(
         this._getChartData(this.dataModel, features[0]));
-  },
-  _hasQuantiles(this: any, features: FeatureNameStatistics[]) {
-    if (features.length === 0) {
-      return false;
-    }
-    if (utils.isFeatureTypeNumeric(this._getFeatureTypeForList(features))) {
-      return utils.hasQuantiles(
-          this._getChartData(this.dataModel, features[0]));
-    }
-    return false;
   },
   _getChartClass(expandCharts: boolean) {
     let classes = 'chart-column ';

--- a/facets_overview/functional_tests/simple/simple_test.ts
+++ b/facets_overview/functional_tests/simple/simple_test.ts
@@ -50,11 +50,12 @@ function create(): DatasetFeatureStatisticsList {
     dataPoints.push({'val': d3.randomNormal(10)(),
                      'val2': d3.randomUniform(0, 5)(),
                      'str1': i < 10 ? 'a' : 'b',
-                     'str2': i < 180 ? 'popular' : 'train-' + i
+                     'str2': i < 180 ? 'popular-value-with-long-name'
+                                     : 'train-' + i
                    });
   }
   let stats = generateStats(dataPoints);
-  stats.setName('train');
+  stats.setName('training-data-with-long-name');
   data.getDatasetsList().push(stats);
 
   dataPoints = [];


### PR DESCRIPTION
- Fix overflow in "show raw data" table in categorical charts
  - Give all divs correct width for table taking into account padding
  - Do not allow header row dataset names to overflow to next lines, ellipsis instead. Their full names are already available in the facets overview legend at top of visualization in case of multiple datsets.

- Do not rely on FeatureNameStatistics.TYPE enum for features for determining how to display tables holding them. This is error-prone for int features being treated as categorical (meaning that they contain string statistics instead of numeric statistics). Instead rely on the already-provided "numeric" boolean.