### PR TITLE
Fix WORKSPACE. Update BUILD files.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,11 +2,11 @@ workspace(name = "ai_google_pair_facets")
 
 http_archive(
     name = "io_bazel_rules_closure",
-    sha256 = "110fe68753413777944b473c25eed6368c4a0487cee23a7bac1b13cc49d3e257",
-    strip_prefix = "rules_closure-4af89ef1db659eb41f110df189b67d4cf14073e1",
+    sha256 = "6691c58a2cd30a86776dd9bb34898b041e37136f2dc7e24cadaeaf599c95c657",
+    strip_prefix = "rules_closure-08039ba8ca59f64248bb3b6ae016460fe9c9914f",
     urls = [
-        "http://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/4af89ef1db659eb41f110df189b67d4cf14073e1.tar.gz",
-        "https://github.com/bazelbuild/rules_closure/archive/4af89ef1db659eb41f110df189b67d4cf14073e1.tar.gz",  # 2017-08-28
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/08039ba8ca59f64248bb3b6ae016460fe9c9914f.tar.gz",
+        "https://github.com/bazelbuild/rules_closure/archive/08039ba8ca59f64248bb3b6ae016460fe9c9914f.tar.gz",  # 2018-01-16
     ],
 )
 
@@ -18,11 +18,11 @@ closure_repositories()
 
 http_archive(
     name = "org_tensorflow_tensorboard",
-    sha256 = "aa75eb5807e83556922bd37db2c0f18acc37cd13bbb4a492e2856fdce3c3236b",
-    strip_prefix = "tensorboard-e75af806d054b54e6891c6196a2fa275c6407390",
+    sha256 = "087242325ef3b91f1909e3fd3a873ad15e3c7703990ad8caab64736d9009bf62",
+    strip_prefix = "tensorboard-1.6.0",
     urls = [
-	    "http://mirror.bazel.build/github.com/tensorflow/tensorboard/archive/e75af806d054b54e6891c6196a2fa275c6407390.tar.gz",  # 2017-10-10
-	    "https://github.com/tensorflow/tensorboard/archive/e75af806d054b54e6891c6196a2fa275c6407390.tar.gz",
+        "http://mirror.bazel.build/github.com/tensorflow/tensorboard/archive/1.6.0.tar.gz",
+        "https://github.com/tensorflow/tensorboard/archive/1.6.0.tar.gz",
     ],
 )
 

--- a/facets/BUILD
+++ b/facets/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "ts_web_library")
+load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
 load("@org_tensorflow_tensorboard//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "visualizations",
     srcs = [
         "visualizations.html",

--- a/facets_dive/components/facets_dive/BUILD
+++ b/facets_dive/components/facets_dive/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "ts_web_library")
+load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
 load("@org_tensorflow_tensorboard//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "facets_dive",
     srcs = [
         "facets-dive.html",
@@ -23,7 +23,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "test",
     testonly = True,
     srcs = [

--- a/facets_dive/components/facets_dive_controls/BUILD
+++ b/facets_dive/components/facets_dive_controls/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "ts_web_library")
+load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
 load("@org_tensorflow_tensorboard//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "facets_dive_controls",
     srcs = [
         "facets-dive-controls.html",
@@ -34,7 +34,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "test",
     testonly = True,
     srcs = [

--- a/facets_dive/components/facets_dive_info_card/BUILD
+++ b/facets_dive/components/facets_dive_info_card/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "ts_web_library")
+load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
 load("@org_tensorflow_tensorboard//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "facets_dive_info_card",
     srcs = [
         "facets-dive-info-card.html",
@@ -20,7 +20,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "test",
     testonly = True,
     srcs = [

--- a/facets_dive/components/facets_dive_vis/BUILD
+++ b/facets_dive/components/facets_dive_vis/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "ts_web_library")
+load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
 load("@org_tensorflow_tensorboard//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "facets_dive_vis",
     srcs = [
         "facets-dive-vis.html",
@@ -32,7 +32,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "test",
     testonly = True,
     srcs = [

--- a/facets_dive/demo/BUILD
+++ b/facets_dive/demo/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "ts_web_library")
+load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
 load("@org_tensorflow_tensorboard//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "quickdraw",
     testonly = True,
     srcs = [

--- a/facets_dive/lib/BUILD
+++ b/facets_dive/lib/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "ts_web_library")
+load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "axis",
     srcs = [
         "axis.html",
@@ -17,7 +17,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "bounded-object",
     srcs = [
         "bounded-object.html",
@@ -26,7 +26,7 @@ ts_web_library(
     path = "/facets-dive/lib",
 )
 
-ts_web_library(
+tf_web_library(
     name = "data-example",
     srcs = [
         "data-example.html",
@@ -35,7 +35,7 @@ ts_web_library(
     path = "/facets-dive/lib",
 )
 
-ts_web_library(
+tf_web_library(
     name = "grid",
     srcs = [
         "grid.html",
@@ -45,7 +45,7 @@ ts_web_library(
     deps = [":sorting"],
 )
 
-ts_web_library(
+tf_web_library(
     name = "info-renderers",
     srcs = [
         "info-renderers.html",
@@ -54,7 +54,7 @@ ts_web_library(
     path = "/facets-dive/lib",
 )
 
-ts_web_library(
+tf_web_library(
     name = "label",
     srcs = [
         "label.html",
@@ -64,7 +64,7 @@ ts_web_library(
     deps = [":sorting"],
 )
 
-ts_web_library(
+tf_web_library(
     name = "layout",
     srcs = [
         "layout.html",
@@ -73,7 +73,7 @@ ts_web_library(
     path = "/facets-dive/lib",
 )
 
-ts_web_library(
+tf_web_library(
     name = "sorting",
     srcs = [
         "sorting.html",
@@ -82,7 +82,7 @@ ts_web_library(
     path = "/facets-dive/lib",
 )
 
-ts_web_library(
+tf_web_library(
     name = "stats",
     srcs = [
         "stats.html",
@@ -92,7 +92,7 @@ ts_web_library(
     deps = [":wordtree"],
 )
 
-ts_web_library(
+tf_web_library(
     name = "string-format",
     srcs = [
         "string-format.html",
@@ -101,7 +101,7 @@ ts_web_library(
     path = "/facets-dive/lib",
 )
 
-ts_web_library(
+tf_web_library(
     name = "text",
     srcs = [
         "text.html",
@@ -110,7 +110,7 @@ ts_web_library(
     path = "/facets-dive/lib",
 )
 
-ts_web_library(
+tf_web_library(
     name = "sprite-atlas",
     srcs = [
         "sprite-atlas.html",
@@ -123,7 +123,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "sprite-material",
     srcs = [
         "sprite-material.html",
@@ -136,7 +136,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "sprite-mesh",
     srcs = [
         "sprite-mesh.html",
@@ -150,7 +150,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "wordtree",
     srcs = [
         "wordtree.html",

--- a/facets_dive/lib/test/BUILD
+++ b/facets_dive/lib/test/BUILD
@@ -4,7 +4,7 @@ package(
 )
 
 load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_library")
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "ts_web_library")
+load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
 load("@org_tensorflow_tensorboard//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
 licenses(["notice"])  # Apache 2.0
@@ -14,7 +14,7 @@ closure_js_library(
     srcs = ["externs.js"],
 )
 
-ts_web_library(
+tf_web_library(
     name = "test",
     srcs = [
         "axis_test.ts",

--- a/facets_overview/common/BUILD
+++ b/facets_overview/common/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "ts_web_library")
+load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "common",
     srcs = [
         "common_bundle.html",

--- a/facets_overview/common/test/BUILD
+++ b/facets_overview/common/test/BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_library")
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "ts_web_library")
+load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
 load("@org_tensorflow_tensorboard//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
 licenses(["notice"])  # Apache 2.0
@@ -11,7 +11,7 @@ closure_js_library(
     srcs = ["externs.js"],
 )
 
-ts_web_library(
+tf_web_library(
     name = "test",
     srcs = [
         "feature_statistics_generator_test.ts",

--- a/facets_overview/components/facets_overview/BUILD
+++ b/facets_overview/components/facets_overview/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "ts_web_library")
+load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "facets_overview",
     srcs = [
         "facets-overview-filter-validator.html",

--- a/facets_overview/components/facets_overview_chart/BUILD
+++ b/facets_overview/components/facets_overview_chart/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "ts_web_library")
+load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "facets_overview_chart",
     srcs = [
         "facets-overview-chart.html",

--- a/facets_overview/components/facets_overview_row_legend/BUILD
+++ b/facets_overview/components/facets_overview_row_legend/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "ts_web_library")
+load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "facets_overview_row_legend",
     srcs = [
         "facets-overview-row-legend.html",

--- a/facets_overview/components/facets_overview_row_stats/BUILD
+++ b/facets_overview/components/facets_overview_row_stats/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "ts_web_library")
+load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "facets_overview_row_stats",
     srcs = [
         "facets-overview-row-stats.html",

--- a/facets_overview/components/facets_overview_table/BUILD
+++ b/facets_overview/components/facets_overview_table/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "ts_web_library")
+load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "facets_overview_table",
     srcs = [
         "facets-overview-table.html",

--- a/facets_overview/functional_tests/many/BUILD
+++ b/facets_overview/functional_tests/many/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "ts_web_library")
+load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
 load("@org_tensorflow_tensorboard//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "many",
     srcs = [
         "many_test.ts",

--- a/facets_overview/functional_tests/simple/BUILD
+++ b/facets_overview/functional_tests/simple/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "ts_web_library")
+load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
 load("@org_tensorflow_tensorboard//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "simple",
     srcs = [
         "simple_test.ts",

--- a/facets_overview/functional_tests/single/BUILD
+++ b/facets_overview/functional_tests/single/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "ts_web_library")
+load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
 load("@org_tensorflow_tensorboard//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "single",
     srcs = [
         "single_test.ts",

--- a/facets_overview/functional_tests/single_feature/BUILD
+++ b/facets_overview/functional_tests/single_feature/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "ts_web_library")
+load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
 load("@org_tensorflow_tensorboard//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "single_feature",
     srcs = [
         "single_feature_test.ts",

--- a/facets_overview/functional_tests/stress/BUILD
+++ b/facets_overview/functional_tests/stress/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "ts_web_library")
+load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
 load("@org_tensorflow_tensorboard//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "stress",
     srcs = [
         "stress_test.ts",

--- a/facets_overview/functional_tests/test_helpers/BUILD
+++ b/facets_overview/functional_tests/test_helpers/BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_library")
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "ts_web_library")
+load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -10,7 +10,7 @@ closure_js_library(
     srcs = ["externs.js"],
 )
 
-ts_web_library(
+tf_web_library(
     name = "test_helpers",
     srcs = [
         "test_helpers.ts",

--- a/facets_overview/functional_tests/weighted/BUILD
+++ b/facets_overview/functional_tests/weighted/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "ts_web_library")
+load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
 load("@org_tensorflow_tensorboard//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "weighted",
     srcs = [
         "weighted_test.ts",


### PR DESCRIPTION
We upgrade the version of `io_bazel_rules_closure` used by facets so
that we can circumvent tensorflow/tensorboard#929.

We correspondingly upgrade the version of TensorBoard referenced within
the WORKSPACE because it should no longer load a certain proto. We
hence also replace `ts_web_library` with `tf_web_library` within BUILD files.

Test plan: Run `bazel run facets:facets`. Verify that bazel builds successfully.

Without this change, bazel outputs a build error.
```
chizeng@direchihuahua:~/Desktop/facetsz$ bazel run facets:facets
ERROR: /home/chizeng/Desktop/facetsz/WORKSPACE:17:1: Traceback (most recent call last):
	File "/home/chizeng/Desktop/facetsz/WORKSPACE", line 17
		closure_repositories()
	File "/home/chizeng/.cache/bazel/_bazel_chizeng/63aca943859989fac6ec8ce8aee5fbb7/external/io_bazel_rules_closure/closure/repositories.bzl", line 69, in closure_repositories
		_check_bazel_version("Closure Rules", "0.4.5")
	File "/home/chizeng/.cache/bazel/_bazel_chizeng/63aca943859989fac6ec8ce8aee5fbb7/external/io_bazel_rules_closure/closure/repositories.bzl", line 172, in _check_bazel_version
		fail(("%s requires Bazel >=%s but was...)))
Closure Rules requires Bazel >=0.4.5 but was 0.11.1
ERROR: Error evaluating WORKSPACE file
ERROR: error loading package '': Encountered error while reading extension file 'third_party/workspace.bzl': no such package '@org_tensorflow_tensorboard//third_party': error loading package 'external': Could not load //external package
ERROR: error loading package '': Encountered error while reading extension file 'third_party/workspace.bzl': no such package '@org_tensorflow_tensorboard//third_party': error loading package 'external': Could not load //external package
INFO: Elapsed time: 1.202s
FAILED: Build did NOT complete successfully (0 packages loaded)
ERROR: Build failed. Not running target
```