### PR TITLE
Fix issue with iron-list rendering in overview tables.

### DIFF
--- a/facets_overview/common/utils.ts
+++ b/facets_overview/common/utils.ts
@@ -979,7 +979,6 @@ export function determineChartTypeForData(
   // Determine if the provided data is numerical.
   let nums = true;
   let maxBuckets = 0;
-  console.log(chartData);
   chartData.forEach(d => {
     if (!d.histMap[chartSelection]) {
       return;

--- a/facets_overview/components/facets_overview_table/facets-overview-table.html
+++ b/facets_overview/components/facets_overview_table/facets-overview-table.html
@@ -42,6 +42,7 @@ limitations under the License.
       }
       .feature-iron-list {
         overflow-x: hidden !important;
+        height: 800px;
       }
       .chart-column {
         width: 280px;

--- a/facets_overview/components/facets_overview_table/facets-overview-table.ts
+++ b/facets_overview/components/facets_overview_table/facets-overview-table.ts
@@ -52,14 +52,16 @@ Polymer({
     // features. Therefore we set the height here based on the number of
     // features to display and if the features are displayed expanded or not.
     const ironList = this.$$('iron-list');
+    if (!ironList || !this._expandedRowHeight || !this._rowHeight ||
+        !this._maxHeight || !this.features) {
+      return;
+    }
     const heightPerElem = this._expandCharts ? this._expandedRowHeight
         : this._rowHeight;
     const length = this.features ? this.features.length : 0;
-    ironList.style.height = Math.min(length * heightPerElem, this._maxHeight)
-        + 'px';
-    if (ironList) {
-      ironList.fire('iron-resize');
-    }
+    const newHeight = Math.min(length * heightPerElem, this._maxHeight);
+    ironList.style.height = newHeight + 'px';
+    ironList.fire('iron-resize');
   },
   // tslint:disable-next-line:no-any typescript/polymer temporary issue
   _computeChartSelectionTypes(

--- a/facets_overview/functional_tests/stress/BUILD
+++ b/facets_overview/functional_tests/stress/BUILD
@@ -49,6 +49,7 @@ tf_web_library(
 #       work in web browsers. Otherwise we'd `bazel run` tf_web_library.
 tensorboard_html_binary(
     name = "devserver",
+    compile = True,
     input_path = "/facets-overview/functional-tests/stress/index.html",
     output_path = "/facets-overview/functional-tests/stress/index.html",
     deps = [":stress"],

--- a/facets_overview/functional_tests/stress/stress_test.ts
+++ b/facets_overview/functional_tests/stress/stress_test.ts
@@ -51,7 +51,7 @@ function create(): DatasetFeatureStatisticsList {
   for (let i = 0; i < 50; i++) {
     const dataPoint1 = {};
     const dataPoint2 = {};
-    for (let j = 0; j < 50; j++) {
+    for (let j = 0; j < 500; j++) {
       dataPoint1['num' + j] = d3.randomNormal(10)();
       dataPoint1['str' + j] = i < 20 ? 'a' : 'b';
       dataPoint2['num' + j] = d3.randomNormal(14)();


### PR DESCRIPTION
  - The facets table was creating and rendering dom for ALL features in the table,
    even though it was only supposed to render the ones visible on screen due to
    the use of iron-list.
  - Fixed by explicitly sizing the list from the beginning and also firing
    iron-resize in appropriate scenarios.
  - Also fixed compile issue for stress test and removed a leftover debug log.