### PR TITLE
display and zoom fixes

### DIFF
--- a/facets_dive/components/facets_dive_controls/facets-dive-controls.html
+++ b/facets_dive/components/facets_dive_controls/facets-dive-controls.html
@@ -131,10 +131,33 @@ limitations under the License.
     </style>
 
     <div class="main-controls">
+        <div class="dropdown-holder horizontal-facet">
+            <paper-dropdown-menu
+                  id="horizontalFacet"
+                  label="Faceting | X-Axis"
+                  class="facet-selector">
+              <paper-listbox class="dropdown-content" selected="{{horizontalFacet}}"
+                  attr-for-selected="value" slot="dropdown-content">
+                <paper-item value="">&lt;NONE&gt;</paper-item>
+                <template is="dom-repeat" items="[[keys]]">
+                  <paper-item value="[[item]]">[[_breakUpAndTruncate(item)]]</paper-item>
+                </template>
+              </paper-listbox>
+            </paper-dropdown-menu>
+          </div>
+
+          <template is="dom-if" if="[[horizontalFacet]]">
+          <paper-input type="number" min="1"
+                  max="[[_maxBuckets(horizontalFacet, horizontalBagOfWords)]]"
+                  value="{{horizontalBuckets}}"
+                  label="X-Axis #Bins">
+            </paper-input>
+          </template>
+
       <div class="dropdown-holder vertical-facet">
         <paper-dropdown-menu
               id="verticalFacet"
-              label="Faceting | X-Axis"
+              label="Faceting | Y-Axis"
               class="facet-selector">
           <paper-listbox class="dropdown-content" selected="{{verticalFacet}}"
               attr-for-selected="value" slot="dropdown-content">
@@ -150,29 +173,6 @@ limitations under the License.
         <paper-input type="number" min="1"
               max="[[_maxBuckets(verticalFacet,verticalBagOfWords)]]"
               value="{{verticalBuckets}}"
-              label="X-Axis #Bins">
-        </paper-input>
-      </template>
-
-      <div class="dropdown-holder horizontal-facet">
-        <paper-dropdown-menu
-              id="horizontalFacet"
-              label="Faceting | Y-Axis"
-              class="facet-selector">
-          <paper-listbox class="dropdown-content" selected="{{horizontalFacet}}"
-              attr-for-selected="value" slot="dropdown-content">
-            <paper-item value="">&lt;NONE&gt;</paper-item>
-            <template is="dom-repeat" items="[[keys]]">
-              <paper-item value="[[item]]">[[_breakUpAndTruncate(item)]]</paper-item>
-            </template>
-          </paper-listbox>
-        </paper-dropdown-menu>
-      </div>
-
-      <template is="dom-if" if="[[horizontalFacet]]">
-      <paper-input type="number" min="1"
-              max="[[_maxBuckets(horizontalFacet, horizontalBagOfWords)]]"
-              value="{{horizontalBuckets}}"
               label="Y-Axis #Bins">
         </paper-input>
       </template>
@@ -192,7 +192,7 @@ limitations under the License.
       <div class="dropdown-holder">
         <paper-dropdown-menu
             id="imageFieldName"
-            label="Display | Type">
+            label="Display | Label">
           <paper-listbox
               class="dropdown-content"
               selected="{{imageFieldName}}"

--- a/facets_dive/components/facets_dive_vis/facets-dive-vis.ts
+++ b/facets_dive/components/facets_dive_vis/facets-dive-vis.ts
@@ -65,7 +65,7 @@ export const CELL_BACKGROUND_FILL_COLOR = '#f8f8f9';
 /**
  * Color for selected item borders.
  */
-const SELECTED_ITEM_COLOR = '#ff0000';
+const SELECTED_ITEM_COLOR = '#da7421';
 
 /**
  * Stroke width for the selected item borders.
@@ -819,7 +819,7 @@ class FacetsDiveVizInternal {
 
     // Create and attach zoom behavior to element.
     this.zoom =
-        d3.zoom().scaleExtent([.01, 1000]).on('zoom', this.zoomed.bind(this));
+        d3.zoom().scaleExtent([1, 500]).on('zoom', this.zoomed.bind(this));
     d3.select(this.elem).call(this.zoom);
 
     // Insert background SVG used for labels and axes.


### PR DESCRIPTION
- Change color of selected item outline (from red to orange) in dive
- Fix the Faceting control dropdowns to be correctly labeled (X and Y axis were swapped)
- Further limit how far in and out you can zoom in dive
- Change "Display | Type" to "Display | Label"