### PR TITLE
Fix AttributeError when handling NaNs in bool col

### DIFF
--- a/facets_overview/python/base_generic_feature_statistics_generator.py
+++ b/facets_overview/python/base_generic_feature_statistics_generator.py
@@ -260,7 +260,8 @@ class BaseGenericFeatureStatisticsGenerator(object):
               strs = []
               for item in value['vals']:
                 strs.append(item if hasattr(item, '__len__') else
-                  item.encode('utf-8'))
+                  item.encode('utf-8') if hasattr(item, 'encode') else str(
+                      item))
 
               featstats.avg_length = np.mean(np.vectorize(len)(strs))
               vals, counts = np.unique(strs, return_counts=True)


### PR DESCRIPTION
Pandas dataframe series with booleans and at least one NaN value is given dtype object instead of bool and this causes failures when trying to treat the bools as strings. This check is verified to now correctly handle this case without affecting other cases. Fixes #127