### PR TITLE
Implementing aspect-ratio grid fitting and other fixes and styles

### DIFF
--- a/facets_dive/README.md
+++ b/facets_dive/README.md
@@ -257,6 +257,13 @@ These optional properties control various stylistic aspects of Dive.
   Label color for item positioning in the horizontal direction.
   If not provided, a reasonable default will be set.
   (Use `item-positioning-horizontal-label-color` in HTML).
+* `fitGridAspectRatioToViewport` - `boolean` -
+  When laying out items in a grid, if this property is set, then the
+  visualization will attempt to match the aspect ratio of the available
+  on-screen space. For example, on a very wide screen, you would expect the grid
+  to also be wide. When this property is not set, then the visualization will
+  lay the grid items out using the default aspect ratio, a square.
+  (Use `fit-grid-aspect-ratio-to-viewport` in HTML).
 
 ### Interactive Properties
 

--- a/facets_dive/README.md
+++ b/facets_dive/README.md
@@ -126,7 +126,7 @@ This feature will likely be drastically changed or removed in the future.
 
 By default, Dive will arrange items within each cell of the grid by stacking them.
 Alternatively, the items can be placed in a scatter plot.
-This is most useful when Faceting is set to `<NONE>`.
+This is most useful when Faceting is set to `(none)`.
 
 Features with numeric values can be used for scatter plot positioning.
 Any items whose value is not a number will still be shown, but the value will be coerced to zero.

--- a/facets_dive/components/facets_dive/facets-dive.html
+++ b/facets_dive/components/facets_dive/facets-dive.html
@@ -67,7 +67,7 @@ limitations under the License.
       facets-dive-legend {
         position: absolute;
         bottom: 14px;
-        left: 80px;
+        right: 24px;
       }
       .zoom-controls {
         bottom: 14px;

--- a/facets_dive/components/facets_dive/facets-dive.html
+++ b/facets_dive/components/facets_dive/facets-dive.html
@@ -151,6 +151,7 @@ limitations under the License.
               grid-faceting-horizontal-label-color="{{gridFacetingHorizontalLabelColor}}"
               item-positioning-vertical-label-color="{{itemPositioningVerticalLabelColor}}"
               item-positioning-horizontal-label-color="{{itemPositioningHorizontalLabelColor}}"
+              fit-grid-aspect-ratio-to-viewport="[[fitGridAspectRatioToViewport]]"
               selected-data="{{selectedData}}"
               selected-indices="{{selectedIndices}}"
             ></facets-dive-vis>

--- a/facets_dive/components/facets_dive/facets-dive.html
+++ b/facets_dive/components/facets_dive/facets-dive.html
@@ -40,54 +40,35 @@ limitations under the License.
         background: #ffffff;
         box-sizing: border-box;
         display: flex;
-        flex: 1;
+        flex-grow: 1;
         height: 100%;
         overflow: hidden;
         position: relative;
         width: 100%;
       }
       .fill {
-        bottom: 0;
-        left: 0;
-        position: absolute;
-        right: 0;
-        top: 0;
+        display: flex;
+        flex-grow: 1;
+        position: relative;
       }
-      #vis {
-        bottom: 0;
-        left: 0;
-        position: absolute;
-        right: 240px;
-        top: 60px;
-        width: auto;
+      .main {
+        flex-direction: column;
       }
-      #controls {
+      facets-dive-controls {
         border-bottom: 1px solid black;
+        flex-grow: 0;
+        flex-shrink: 0;
         height: 60px;
-        left: 0;
-        position: absolute;
-        right: 0;
-        top: 0;
       }
-      #infoCard {
-        background: #fff8f4;
-        bottom: 0;
-        border-left: 1px solid #c6c6c6;
-        box-sizing: border-box;
-        position: absolute;
-        right: 0;
-        top: 61px;
-        width: 240px;
+      .row {
+        display: flex;
+        flex-direction: row;
       }
-      #legend {
+      facets-dive-legend {
         position: absolute;
         bottom: 14px;
         left: 80px;
       }
-
-      /**
-       * Zoom Controls.
-       */
       .zoom-controls {
         bottom: 14px;
         box-sizing: border-box;
@@ -104,42 +85,17 @@ limitations under the License.
         min-width: 0;
         padding: 8px;
       }
+      facets-dive-info-card {
+        background: #fff8f4;
+        border-left: 1px solid #c6c6c6;
+        box-sizing: border-box;
+        flex-grow: 0;
+        flex-shrink: 0;
+        width: 240px;
+      }
     </style>
 
-    <div class="fill">
-      <facets-dive-vis
-          id="vis"
-          class="fill"
-          data="[[data]]"
-          filtered-data-indices="[[filteredDataIndices]]"
-          atlas-url="[[atlasUrl]]"
-          sprite-url="[[spriteUrl]]"
-          cross-origin="[[crossOrigin]]"
-          keys="{{_keys}}"
-          stats="{{stats}}"
-          sprite-image-width="[[spriteImageWidth]]"
-          sprite-image-height="[[spriteImageHeight]]"
-          vertical-facet="[[verticalFacet]]"
-          vertical-buckets="[[verticalBuckets]]"
-          vertical-bag-of-words="[[verticalBagOfWords]]"
-          horizontal-facet="[[horizontalFacet]]"
-          horizontal-buckets="[[horizontalBuckets]]"
-          horizontal-bag-of-words="[[horizontalBagOfWords]]"
-          position-mode="[[positionMode]]"
-          vertical-position="[[verticalPosition]]"
-          horizontal-position="[[horizontalPosition]]"
-          color-by="{{colorBy}}"
-          image-field-name="{{imageFieldName}}"
-          palette="{{_palette}}"
-          palette-choice="[[paletteChoice]]"
-          grid-faceting-vertical-label-color="{{gridFacetingVerticalLabelColor}}"
-          grid-faceting-horizontal-label-color="{{gridFacetingHorizontalLabelColor}}"
-          item-positioning-vertical-label-color="{{itemPositioningVerticalLabelColor}}"
-          item-positioning-horizontal-label-color="{{itemPositioningHorizontalLabelColor}}"
-          selected-data="{{selectedData}}"
-          selected-indices="{{selectedIndices}}"
-        ></facets-dive-vis>
-
+    <div class="fill main">
       <facets-dive-controls
           id="controls"
           atlas-url="[[atlasUrl]]"
@@ -164,29 +120,66 @@ limitations under the License.
           item-positioning-horizontal-label-color="[[itemPositioningHorizontalLabelColor]]"
         ></facets-dive-controls>
 
-      <div class="zoom-controls">
-        <paper-button raised id="zoomInButton">
-          <iron-icon icon="icons:add"></iron-icon>
-        </paper-button>
-        <paper-button raised id="zoomOutButton">
-          <iron-icon icon="icons:remove"></iron-icon>
-        </paper-button>
-        <paper-button raised id="fitButton">
-          <iron-icon icon="icons:aspect-ratio"></iron-icon>
-        </paper-button>
+      <div class="fill row">
+        <div class="fill">
+          <facets-dive-vis
+              id="vis"
+              class="fill"
+              data="[[data]]"
+              filtered-data-indices="[[filteredDataIndices]]"
+              atlas-url="[[atlasUrl]]"
+              sprite-url="[[spriteUrl]]"
+              cross-origin="[[crossOrigin]]"
+              keys="{{_keys}}"
+              stats="{{stats}}"
+              sprite-image-width="[[spriteImageWidth]]"
+              sprite-image-height="[[spriteImageHeight]]"
+              vertical-facet="[[verticalFacet]]"
+              vertical-buckets="[[verticalBuckets]]"
+              vertical-bag-of-words="[[verticalBagOfWords]]"
+              horizontal-facet="[[horizontalFacet]]"
+              horizontal-buckets="[[horizontalBuckets]]"
+              horizontal-bag-of-words="[[horizontalBagOfWords]]"
+              position-mode="[[positionMode]]"
+              vertical-position="[[verticalPosition]]"
+              horizontal-position="[[horizontalPosition]]"
+              color-by="{{colorBy}}"
+              image-field-name="{{imageFieldName}}"
+              palette="{{_palette}}"
+              palette-choice="[[paletteChoice]]"
+              grid-faceting-vertical-label-color="{{gridFacetingVerticalLabelColor}}"
+              grid-faceting-horizontal-label-color="{{gridFacetingHorizontalLabelColor}}"
+              item-positioning-vertical-label-color="{{itemPositioningVerticalLabelColor}}"
+              item-positioning-horizontal-label-color="{{itemPositioningHorizontalLabelColor}}"
+              selected-data="{{selectedData}}"
+              selected-indices="{{selectedIndices}}"
+            ></facets-dive-vis>
+
+          <div class="zoom-controls">
+            <paper-button raised id="zoomInButton">
+              <iron-icon icon="icons:add"></iron-icon>
+            </paper-button>
+            <paper-button raised id="zoomOutButton">
+              <iron-icon icon="icons:remove"></iron-icon>
+            </paper-button>
+            <paper-button raised id="fitButton">
+              <iron-icon icon="icons:aspect-ratio"></iron-icon>
+            </paper-button>
+          </div>
+
+          <facets-dive-legend id="legend" color-by="[[colorBy]]"
+              palette="[[_palette]]">
+          </facets-dive-legend>
+        </div>
+
+        <template is="dom-if" if="[[!hideInfoCard]]">
+          <facets-dive-info-card
+              id="infoCard"
+              selected-data="[[selectedData]]"
+              info-renderer="[[infoRenderer]]">
+          </facets-dive-info-card>
+        </template>
       </div>
-
-      <facets-dive-legend id="legend" color-by="[[colorBy]]"
-          palette="[[_palette]]">
-      </facets-dive-legend>
-
-      <template is="dom-if" if="[[!hideInfoCard]]">
-        <facets-dive-info-card
-            id="infoCard"
-            selected-data="[[selectedData]]"
-            info-renderer="[[infoRenderer]]">
-        </facets-dive-info-card>
-      </template>
     </div>
 
   </template>

--- a/facets_dive/components/facets_dive/facets-dive.ts
+++ b/facets_dive/components/facets_dive/facets-dive.ts
@@ -92,6 +92,13 @@ export interface FacetsDive extends Element {
   itemPositioningVerticalLabelColor: string;
   itemPositioningHorizontalLabelColor: string;
 
+  /**
+   * Whether to attempt to fill available visualization area when arranging
+   * items into the grid. If missing/false, then the default aspect ratio of 1
+   * (square) will be used.
+   */
+  fitGridAspectRatioToViewport: boolean;
+
   // INTER-COMPONENT WIRING PROPERTIES.
 
   /**
@@ -263,6 +270,10 @@ Polymer({
     itemPositioningHorizontalLabelColor: {
       type: String,
       value: vis.ITEM_POSITIONING_HORIZONTAL_LABEL_COLOR,
+    },
+    fitGridAspectRatioToViewport: {
+      type: Boolean,
+      value: false,
     },
     verticalFacet: {
       type: String,

--- a/facets_dive/components/facets_dive_controls/facets-dive-controls.html
+++ b/facets_dive/components/facets_dive_controls/facets-dive-controls.html
@@ -210,7 +210,7 @@ limitations under the License.
       <div class="dropdown-holder horizontal-position">
         <paper-dropdown-menu
               id="horizontalPosition"
-              label="Position | X-Axis"
+              label="Scatter | X-Axis"
               class="position-selector">
           <paper-listbox
               class="dropdown-content"
@@ -228,7 +228,7 @@ limitations under the License.
       <div class="dropdown-holder vertical-position">
         <paper-dropdown-menu
               id="verticalPosition"
-              label="Position | Y-Axis"
+              label="Scatter | Y-Axis"
               class="position-selector">
           <paper-listbox
               class="dropdown-content"

--- a/facets_dive/components/facets_dive_controls/facets-dive-controls.html
+++ b/facets_dive/components/facets_dive_controls/facets-dive-controls.html
@@ -134,11 +134,11 @@ limitations under the License.
         <div class="dropdown-holder horizontal-facet">
             <paper-dropdown-menu
                   id="horizontalFacet"
-                  label="Faceting | X-Axis"
+                  label="Binning | X-Axis"
                   class="facet-selector">
               <paper-listbox class="dropdown-content" selected="{{horizontalFacet}}"
                   attr-for-selected="value" slot="dropdown-content">
-                <paper-item value="">&lt;NONE&gt;</paper-item>
+                <paper-item value="">(none)</paper-item>
                 <template is="dom-repeat" items="[[keys]]">
                   <paper-item value="[[item]]">[[_breakUpAndTruncate(item)]]</paper-item>
                 </template>
@@ -150,18 +150,18 @@ limitations under the License.
           <paper-input type="number" min="1"
                   max="[[_maxBuckets(horizontalFacet, horizontalBagOfWords)]]"
                   value="{{horizontalBuckets}}"
-                  label="X-Axis #Bins">
+                  label="Count">
             </paper-input>
           </template>
 
       <div class="dropdown-holder vertical-facet">
         <paper-dropdown-menu
               id="verticalFacet"
-              label="Faceting | Y-Axis"
+              label="Binning | Y-Axis"
               class="facet-selector">
           <paper-listbox class="dropdown-content" selected="{{verticalFacet}}"
               attr-for-selected="value" slot="dropdown-content">
-            <paper-item value="">&lt;NONE&gt;</paper-item>
+            <paper-item value="">(none)</paper-item>
             <template is="dom-repeat" items="[[keys]]">
               <paper-item value="[[item]]">[[_breakUpAndTruncate(item)]]</paper-item>
             </template>
@@ -173,15 +173,15 @@ limitations under the License.
         <paper-input type="number" min="1"
               max="[[_maxBuckets(verticalFacet,verticalBagOfWords)]]"
               value="{{verticalBuckets}}"
-              label="Y-Axis #Bins">
+              label="Count">
         </paper-input>
       </template>
 
       <div class="dropdown-holder">
-        <paper-dropdown-menu id="colorBy" label="Display | Color">
+        <paper-dropdown-menu id="colorBy" label="Color By">
           <paper-listbox class="dropdown-content" selected="{{colorBy}}"
               attr-for-selected="value" slot="dropdown-content">
-            <paper-item value="">&lt;NONE&gt;</paper-item>
+            <paper-item value="">(none)</paper-item>
             <template is="dom-repeat" items="[[keys]]">
               <paper-item value="[[item]]">[[item]]</paper-item>
             </template>
@@ -192,7 +192,7 @@ limitations under the License.
       <div class="dropdown-holder">
         <paper-dropdown-menu
             id="imageFieldName"
-            label="Display | Label">
+            label="Label By">
           <paper-listbox
               class="dropdown-content"
               selected="{{imageFieldName}}"
@@ -216,7 +216,7 @@ limitations under the License.
               class="dropdown-content"
               selected="{{horizontalPosition}}"
               attr-for-selected="value" slot="dropdown-content">
-            <paper-item value="">&lt;DEFAULT&gt;</paper-item>
+            <paper-item value="">(default)</paper-item>
             <template is="dom-repeat" items="[[keys]]"
                 filter="_isKeyNumeric">
               <paper-item value="[[item]]">[[item]]</paper-item>
@@ -234,7 +234,7 @@ limitations under the License.
               class="dropdown-content"
               selected="{{verticalPosition}}"
               attr-for-selected="value" slot="dropdown-content">
-            <paper-item value="">&lt;DEFAULT&gt;</paper-item>
+            <paper-item value="">(default)</paper-item>
             <template is="dom-repeat" items="[[keys]]"
                 filter="_isKeyNumeric">
               <paper-item value="[[item]]">[[item]]</paper-item>

--- a/facets_dive/components/facets_dive_controls/facets-dive-controls.ts
+++ b/facets_dive/components/facets_dive_controls/facets-dive-controls.ts
@@ -224,7 +224,7 @@ Polymer({
   },
 
   _getImageFieldNameDefaultLabel(atlasUrl: string): string {
-    return atlasUrl ? '<IMAGE>' : '<DEFAULT>';
+    return atlasUrl ? '(image)' : '(default)';
   },
 
   _isModeScatter(positionMode: string): boolean {
@@ -287,8 +287,9 @@ Polymer({
    */
   _getPositionMode(
       this: any, verticalPosition: string, horizontalPosition: string) {
-    return verticalPosition == '' && horizontalPosition == ''
-        ? vis.DEFAULT_POSITION_MODE : 'scatter';
+    return verticalPosition == '' && horizontalPosition == '' ?
+        vis.DEFAULT_POSITION_MODE :
+        'scatter';
   },
 
   /**
@@ -305,7 +306,7 @@ Polymer({
   _shouldShowOverflowMenu(
       this: any, colorBy: string, verticalFacet: string,
       horizontalFacet: string) {
-    return this._isKeyCategorical(colorBy) || this._hasWordTree(verticalFacet)
-        || this._hasWordTree(horizontalFacet);
+    return this._isKeyCategorical(colorBy) ||
+        this._hasWordTree(verticalFacet) || this._hasWordTree(horizontalFacet);
   },
 });

--- a/facets_dive/components/facets_dive_vis/facets-dive-vis.ts
+++ b/facets_dive/components/facets_dive_vis/facets-dive-vis.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -385,14 +385,14 @@ export class Label extends BoundedObject {
    * Additional attributes to set for this label. Examples include font-size,
    * text-anchor, x and y (local user-space coordinates).
    */
-  attributes?: {[name: string]: number | string};
+  attributes?: {[name: string]: number|string};
 }
 
 /**
  * Palette object maps a label string onto a color that should be used in
  * any items that match that label.
  */
-export type Palette = Array < {
+export type Palette = Array<{
   /**
    * Key value which maps to this color.
    */
@@ -407,8 +407,7 @@ export type Palette = Array < {
    * Label string and special status to show for this color.
    */
   content: LabelContent;
-}
-> ;
+}>;
 
 type FacetingFunction = (item: GridItem) => (Key|null);
 
@@ -516,6 +515,13 @@ export interface FacetsDiveVis extends HTMLElement {
   gridFacetingHorizontalLabelColor: string;
   itemPositioningVerticalLabelColor: string;
   itemPositioningHorizontalLabelColor: string;
+
+  /**
+   * Whether to attempt to fill available visualization area when arranging
+   * items into the grid. If missing/false, then the default aspect ratio of 1
+   * (square) will be used.
+   */
+  fitGridAspectRatioToViewport: boolean;
 
   // USER-INTERACTION PROPERTIES.
 
@@ -836,8 +842,9 @@ class FacetsDiveVizInternal {
         'class', 'labels');
     this.axesLayer = this.labelsAndAxesSVGRoot.append<SVGGElement>('g').attr(
         'class', 'axes');
-    this.selectedLayer = this.labelsAndAxesSVGRoot.append<SVGGElement>('g')
-        .attr('class', 'selectedboxes');
+    this.selectedLayer =
+        this.labelsAndAxesSVGRoot.append<SVGGElement>('g').attr(
+            'class', 'selectedboxes');
 
     // Set up click handler for labels and axes SVG.
     this.labelsAndAxesSVG.on('click', this.clicked.bind(this));
@@ -906,8 +913,9 @@ class FacetsDiveVizInternal {
     for (let i = 0; i < spriteIndexes.length; i++) {
       selectedIndicesSet[spriteIndexes[i]] = true;
     }
-    this.elem.set('selectedIndices', Array.from(Object.keys(selectedIndicesSet)
-      .map(key => +key)));
+    this.elem.set(
+        'selectedIndices',
+        Array.from(Object.keys(selectedIndicesSet).map(key => +key)));
     const selectedData = [];
     for (let i = 0; i < this.elem.selectedIndices.length; i++) {
       selectedData.push(this.elem.data[this.elem.selectedIndices[i]]);
@@ -932,13 +940,16 @@ class FacetsDiveVizInternal {
    */
   updateSelectedBoxes() {
     const selectedBoxes: ItemPosition[] =
-      this.elem.selectedIndices.map(index => {
-        return {x: this.spriteMesh.getX(index), y: this.spriteMesh.getY(index)};
-    });
+        this.elem.selectedIndices.map(index => {
+          return {
+            x: this.spriteMesh.getX(index),
+            y: this.spriteMesh.getY(index)
+          };
+        });
 
     // JOIN.
-    const selectedElements = this.selectedLayer.selectAll('.selected').data(
-      selectedBoxes);
+    const selectedElements =
+        this.selectedLayer.selectAll('.selected').data(selectedBoxes);
 
     selectedElements
         // ENTER.
@@ -2043,6 +2054,14 @@ class FacetsDiveVizInternal {
     this.grid.horizontalFacet = horizontalFacetInfo.facetingFunction;
     this.grid.horizontalKeyCompare = horizontalFacetInfo.keyCompareFunction;
 
+    if (this.elem.fitGridAspectRatioToViewport) {
+      const rect = this.elem.getBoundingClientRect();
+      this.grid.targetGridAspectRatio =
+          rect && rect.width && rect.height ? rect.width / rect.height || 1 : 1;
+    } else {
+      this.grid.targetGridAspectRatio = 1;
+    }
+
     this.grid.arrange();
 
     this.updateCellBackgrounds();
@@ -2974,6 +2993,10 @@ Polymer({
     itemPositioningHorizontalLabelColor: {
       type: String,
       value: ITEM_POSITIONING_HORIZONTAL_LABEL_COLOR,
+    },
+    fitGridAspectRatioToViewport: {
+      type: Boolean,
+      value: false,
     },
     verticalFacet: {
       type: String,


### PR DESCRIPTION
* Fix overflow on initialization by switching from absolute positioning to flex.
* Implement `fitGridAspectRatioToViewport` option to fill available space when desired, rather than always targeting a square aspect ratio.
* Minor changes per mocks: move legend, change control input labels.