### PR TITLE
Implementing 'comparedIndices' feature

### DIFF
--- a/facets_dive/README.md
+++ b/facets_dive/README.md
@@ -315,4 +315,11 @@ These are typically controlled by the user, but can also be set programatically 
 * `infoRenderer?` - `(dataObject: {}, containerElem: Element) => void` -
   Callback function to use to render the content of a data object for the info pane.
   If not specified, the `FacetsDiveInfoCard.defaultInfoRenderer` will be used.
-
+* `comparedIndices` - `Array<number>` -
+  Property listing indices of data objects to compare to the selected ones.
+  Set this programatically, will automatically update `comparedData` to match.
+* `comparedData` - `Array<{}>` -
+  READ ONLY.
+  Data objects to be compared to the selected objects.
+  They will all be elements of the data array.
+  Changed automatically in response to changes to `comparedIndices`.

--- a/facets_dive/components/facets_dive/facets-dive.html
+++ b/facets_dive/components/facets_dive/facets-dive.html
@@ -154,6 +154,8 @@ limitations under the License.
               fit-grid-aspect-ratio-to-viewport="[[fitGridAspectRatioToViewport]]"
               selected-data="{{selectedData}}"
               selected-indices="{{selectedIndices}}"
+              compared-data="{{comparedData}}"
+              compared-indices="{{comparedIndices}}"
             ></facets-dive-vis>
 
           <div class="zoom-controls">

--- a/facets_dive/components/facets_dive/facets-dive.ts
+++ b/facets_dive/components/facets_dive/facets-dive.ts
@@ -190,6 +190,18 @@ export interface FacetsDive extends Element {
    */
   selectedData: Array<{}>;
 
+  /**
+   * Indices of data objects to compare against those that are selected. Set
+   * programmatically, influences comparedData.
+   */
+  comparedIndices: number[];
+
+  /**
+   * The currently compared data objects. They should all be elements of the
+   * data array. Changed in response to updates to the comparedIndices.
+   */
+  comparedData: Array<{}>;
+
   // STYLE PROPERTIES.
 
   /**
@@ -345,6 +357,16 @@ Polymer({
       notify: true,
     },
     selectedIndices: {
+      type: Array,
+      value: [],
+      notify: true,
+    },
+    comparedData: {
+      type: Array,
+      value: [],
+      notify: true,
+    },
+    comparedIndices: {
       type: Array,
       value: [],
       notify: true,


### PR DESCRIPTION
Allows comparing a set of data points against those which were selected manually through user interaction.

To test this feature, first run the Facets Dive integration test:

```
$ bazel run //facets_dive/components/facets_dive:devserver
```

Once it's running, open a browser to `http://<host>:6006/facets-dive/components/facets-dive/runner.html`. Then open the browser's console and enter the following:

```
$$('facets-dive')[0].comparedIndices = [1,4]
```

You should see two cyan colored boxes around the `banana` and `eggs` data points. Setting other indices in the array should have comparable results.
