### PR TITLE
Add feature path to match TF data validation

### DIFF
--- a/facets_overview/common/utils.ts
+++ b/facets_overview/common/utils.ts
@@ -479,8 +479,7 @@ export function cleanProto(datasets: DatasetFeatureStatisticsList):
       if (path != null) {
         const steps = path.getStepList();
         if (steps != null) {
-          feature.setName(steps.reduce(
-            (accumulator, currentValue) => accumulator + '/' + currentValue));
+          feature.setName(steps.join('/'));
         }
       }
 

--- a/facets_overview/common/utils.ts
+++ b/facets_overview/common/utils.ts
@@ -462,8 +462,9 @@ export function isFeatureTypeNumeric(type: FeatureNameStatistics.Type) {
 /**
  * Cleans the provided DatasetFeatureStatisticsList proto by copying all
  * deprecated fields to their non-deprecated version if the deprecated field
- * is set and the non-deprecated field is not set. This method alters the proto
- * in place and also returns it as a convinience.
+ * is set and the non-deprecated field is not set and performing other clean-up
+ * operations. This method alters the proto in place and also returns it as a
+ * convinience.
  */
 export function cleanProto(datasets: DatasetFeatureStatisticsList):
     DatasetFeatureStatisticsList {
@@ -472,6 +473,17 @@ export function cleanProto(datasets: DatasetFeatureStatisticsList):
   // deprecated field into the non-deprecated field.
   datasets.getDatasetsList().forEach(dataset => {
     dataset.getFeaturesList().forEach(feature => {
+      // If the feature's path step list is set, then use this path to create
+      // the feature's name, separated by forward slashes.
+      const path = feature.getPath();
+      if (path != null) {
+        const steps = path.getStepList();
+        if (steps != null) {
+          feature.setName(steps.reduce(
+            (accumulator, currentValue) => accumulator + '/' + currentValue));
+        }
+      }
+
       let hists: GenericHistogram[] = [];
       if (feature.getStringStats()) {
         const h = feature.getStringStats()!.getRankHistogram();

--- a/facets_overview/components/facets_overview/facets-overview.html
+++ b/facets_overview/components/facets_overview/facets-overview.html
@@ -176,7 +176,7 @@ limitations under the License.
             Reverse order
           </paper-checkbox>
           <paper-input class="right-input input-control"
-                       label="Feature search"
+                       label="Feature search (regex enabled)"
                        value="{{searchString}}"
                        auto-validate="true"
                        validator="filter-validator">

--- a/facets_overview/functional_tests/simple/simple_test.ts
+++ b/facets_overview/functional_tests/simple/simple_test.ts
@@ -17,6 +17,7 @@
 import DatasetFeatureStatisticsList from 'goog:proto.featureStatistics.DatasetFeatureStatisticsList';
 import FeatureNameStatistics from 'goog:proto.featureStatistics.FeatureNameStatistics';
 import Histogram from 'goog:proto.featureStatistics.Histogram';
+import Path from 'goog:proto.featureStatistics.Path';
 import RankHistogram from 'goog:proto.featureStatistics.RankHistogram';
 import { DataPoint, generateStats } from '../../common/feature_statistics_generator';
 import { FeatureSelection } from '../../common/utils';
@@ -55,6 +56,10 @@ function create(): DatasetFeatureStatisticsList {
                    });
   }
   let stats = generateStats(dataPoints);
+  let featureStats = stats.getFeaturesList()[1];
+  const path = new Path();
+  path.setStepList(['root', 'dir', 'val2']);
+  featureStats.setPath(path);
   stats.setName('training-data-with-long-name');
   data.getDatasetsList().push(stats);
 
@@ -82,7 +87,7 @@ function create(): DatasetFeatureStatisticsList {
   const customRankHist = th.makeRankHistogram([
     th.makeRankBucket('label1', 0, 0, 10), th.makeRankBucket('label2', 1, 1, 6)
   ]);
-  const featureStats = stats.getFeaturesList()[0];
+  featureStats = stats.getFeaturesList()[0];
   const customStats = [th.makeCustomStatistic('customHist', customHist),
                        th.makeCustomStatistic('customNum', 13.1),
                        th.makeCustomStatistic('customRankHist', customRankHist),

--- a/facets_overview/proto/feature_statistics.proto
+++ b/facets_overview/proto/feature_statistics.proto
@@ -26,6 +26,13 @@ message DatasetFeatureStatisticsList {
   repeated DatasetFeatureStatistics datasets = 1;
 }
 
+// A Path is a structured way to identify features, as opposed to flat names.
+message Path {
+  // Any string is a valid step.
+  // However, whenever possible have a step be [A-Za-z0-9_]+.
+  repeated string step = 1;
+}
+
 // The feature statistics for a single dataset.
 message DatasetFeatureStatistics {
   // The name of the dataset.
@@ -54,8 +61,18 @@ message FeatureNameStatistics {
     STRUCT = 4;
   }
 
-  // The feature name
-  string name = 1;
+  // One can identify a feature either by the name (for simple fields), or by
+  // a path (for structured fields). Note that:
+  // name: "foo"
+  // is equivalent to:
+  // path: {step:"foo"}
+  oneof field_id {
+    // The feature name
+    string name = 1;
+
+    // The path of the feature.
+    Path path = 8;
+  }
 
   // The data type of the feature
   Type type = 2;


### PR DESCRIPTION
Add Path field to FeatureNameStatistics to match TF data validation's feature stats proto.

- If Path is set, then construct the name from the path list
- Include a path example in the functional tests
- Added text to feature search box to indicate that it supports regex