### PR TITLE
Add scikit-image to requirements.txt (atlasmaker)

### DIFF
--- a/facets_atlasmaker/requirements.txt
+++ b/facets_atlasmaker/requirements.txt
@@ -5,3 +5,4 @@ nose
 pillow
 pylint
 requests
+scikit-image


### PR DESCRIPTION
The package scikit-image turns out to be required in order to make use of the atlasmaker tool. So I added it to the requirements file.