### PR TITLE
Updates to Polymer2 branch

### DIFF
--- a/facets_dive/components/facets_dive_controls/BUILD
+++ b/facets_dive/components/facets_dive_controls/BUILD
@@ -17,7 +17,6 @@ tf_web_library(
         "//facets_dive/lib:stats",
         "//facets_dive/lib:string-format",
         "@org_polymer_iron_icons",
-        "@org_polymer_neon_animation",
         "@org_polymer_paper_checkbox",
         "@org_polymer_paper_dialog",
         "@org_polymer_paper_dropdown_menu",

--- a/facets_dive/components/facets_dive_controls/facets-dive-controls.html
+++ b/facets_dive/components/facets_dive_controls/facets-dive-controls.html
@@ -15,7 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <link rel="import" href="../../../polymer/polymer.html">
-<link rel="import" href="../../../neon-animation/web-animations.html">
 <link rel="import" href="../../../paper-checkbox/paper-checkbox.html">
 <link rel="import" href="../../../paper-dialog/paper-dialog.html">
 <link rel="import" href="../../../paper-dropdown-menu/paper-dropdown-menu.html">

--- a/facets_overview/components/facets_overview_chart/BUILD
+++ b/facets_overview/components/facets_overview_chart/BUILD
@@ -36,8 +36,6 @@ tf_web_library(
         "@org_polymer_paper_checkbox",
         "@org_tensorflow_tensorboard//tensorboard/components/tf_imports:d3",
         "@org_tensorflow_tensorboard//tensorboard/components/tf_imports:plottable",
-        # HACK: plottable.css from :plottable is not accessible. Should investigate.
-        "@org_tensorflow_tensorboard//tensorboard/components/tf_imports:plottable_js_css",
         "@org_tensorflow_tensorboard//tensorboard/components/tf_imports:polymer",
     ],
 )

--- a/facets_overview/components/facets_overview_chart/facets-overview-chart.html
+++ b/facets_overview/components/facets_overview_chart/facets-overview-chart.html
@@ -23,7 +23,7 @@ limitations under the License.
 
 <dom-module id='facets-overview-chart'>
   <template>
-    <link rel="stylesheet" href="../../../tf-imports/plottable.css">
+    <style include="plottable-style"></style>
     <style>
       .plottable.chart-small {
         height: 46px;

--- a/facets_overview/components/facets_overview_table/BUILD
+++ b/facets_overview/components/facets_overview_table/BUILD
@@ -28,7 +28,6 @@ tf_web_library(
         "//facets_overview/components/facets_overview_row_stats",
         "//facets_overview/proto:feature_statistics_closure_proto",
         "@org_polymer_iron_list",
-        "@org_polymer_neon_animation",
         "@org_polymer_paper_dropdown_menu",
         "@org_polymer_paper_item",
         "@org_polymer_paper_listbox",

--- a/facets_overview/components/facets_overview_table/facets-overview-table.html
+++ b/facets_overview/components/facets_overview_table/facets-overview-table.html
@@ -16,7 +16,6 @@ limitations under the License.
 -->
 <link rel="import" href="../../../polymer/polymer.html">
 <link rel="import" href="../../../iron-list/iron-list.html">
-<link rel="import" href="../../../neon-animation/web-animations.html">
 <link rel="import" href="../../../paper-dropdown-menu/paper-dropdown-menu.html">
 <link rel="import" href="../../../paper-item/paper-item.html">
 <link rel="import" href="../../../paper-listbox/paper-listbox.html">


### PR DESCRIPTION
TensorBoard will not expose the `plottable_js_css`. Instead, Facets should use this syntax.

The second commit contains removal of `web-animations.html` which pulls in a polyfill for web-animation which seems to be very incompatible with the app. Note that importing neon-animation does not, by default, pull in the web-animations.html. 