### PR TITLE
Fix feature stats generation when examples contain encoded images

### DIFF
--- a/facets_overview/python/base_generic_feature_statistics_generator.py
+++ b/facets_overview/python/base_generic_feature_statistics_generator.py
@@ -272,7 +272,7 @@ class BaseGenericFeatureStatisticsGenerator(object):
               for val_index, val in enumerate(sorted_vals):
                 try:
                   if (sys.version_info.major < 3 or
-                      isinstance(data, (bytes, bytearray))):
+                      isinstance(val[1], (bytes, bytearray))):
                     printable_val = val[1].decode('UTF-8', 'strict')
                   else:
                     printable_val = val[1]

--- a/facets_overview/python/base_generic_feature_statistics_generator.py
+++ b/facets_overview/python/base_generic_feature_statistics_generator.py
@@ -19,6 +19,7 @@ The proto is used as input for the Overview visualization.
 
 import numpy as np
 import pandas as pd
+import sys
 
 
 class BaseGenericFeatureStatisticsGenerator(object):
@@ -273,7 +274,11 @@ class BaseGenericFeatureStatisticsGenerator(object):
                   printable_val = val[1]
                 else:
                   try:
-                    printable_val = val[1].decode('UTF-8', 'strict')
+                    if (sys.version_info.major < 3 or
+                        isinstance(data, (bytes, bytearray))):
+                      printable_val = val[1].decode('UTF-8', 'strict')
+                    else:
+                      printable_val = val[1]
                   except (UnicodeDecodeError, UnicodeEncodeError):
                     printable_val = '__BYTES_VALUE__'
                 bucket = featstats.rank_histogram.buckets.add(

--- a/facets_overview/python/base_generic_feature_statistics_generator.py
+++ b/facets_overview/python/base_generic_feature_statistics_generator.py
@@ -270,17 +270,14 @@ class BaseGenericFeatureStatisticsGenerator(object):
               sorted_vals = sorted(zip(counts, vals), reverse=True)
               sorted_vals = sorted_vals[:histogram_categorical_levels_count]
               for val_index, val in enumerate(sorted_vals):
-                if val[1].dtype.type is np.str_:
-                  printable_val = val[1]
-                else:
-                  try:
-                    if (sys.version_info.major < 3 or
-                        isinstance(data, (bytes, bytearray))):
-                      printable_val = val[1].decode('UTF-8', 'strict')
-                    else:
-                      printable_val = val[1]
-                  except (UnicodeDecodeError, UnicodeEncodeError):
-                    printable_val = '__BYTES_VALUE__'
+                try:
+                  if (sys.version_info.major < 3 or
+                      isinstance(data, (bytes, bytearray))):
+                    printable_val = val[1].decode('UTF-8', 'strict')
+                  else:
+                    printable_val = val[1]
+                except (UnicodeDecodeError, UnicodeEncodeError):
+                  printable_val = '__BYTES_VALUE__'
                 bucket = featstats.rank_histogram.buckets.add(
                     low_rank=val_index,
                     high_rank=val_index,


### PR DESCRIPTION
When examples contain encoded images inside of bytes_list features, the feature stats generation code fails, when using python 2.

Updated the code to correctly handle standard printable strings AND encoded image strings in bytes_list features, in both python 2 and python 3.

Tested and verified in a colab notebook on examples with both kinds of bytes_lists features, in both py2 and py3.