### PR TITLE
Fixed urllib import

### DIFF
--- a/facets_atlasmaker/atlasmaker_io.py
+++ b/facets_atlasmaker/atlasmaker_io.py
@@ -4,7 +4,11 @@ import io
 import json
 import os
 import time
-from urllib.parse import urlparse
+import sys
+if sys.version_info[0] == 2:
+  from urlparse import urlparse
+else:
+  from urllib.parse import urlparse
 from absl import logging
 from PIL import Image
 import requests


### PR DESCRIPTION
In python 3 urlparse has been renamed urllib, so that the import needs to be updated.