### PR TITLE
Fixing zoomed options bugs #209, #214

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you make code changes to the visualization and would like to rebuild them, fo
 
 If you want to use the visualizations you built locally in a Jupyter notebook, follow these directions:
 
-1. Move the resulting vulcanized html file from the build step into the facets-dist directory.
+1. Move the resulting vulcanized html file from the build step into the facets-dist directory: ```cp -f bazel-bin/facets/facets-jupyter.html facets-dist/```
 2. Install the visualizations into Jupyter as an nbextension.
   * If jupyter was installed with pip, you can use ```jupyter nbextension install facets-dist/ ``` if jupyter was installed system-wide or ```jupyter nbextension install facets-dist/ --user``` if installed per-user (run from the facets top-level directory). You do not need to run any follow-up ```jupyter nbextension enable``` command for this extension.
   * Alternatively, you can manually install the nbextension by finding your jupyter installation's ```share/jupyter/nbextensions``` folder and copying the facets-dist directory into it.

--- a/facets-dist/facets-jupyter.html
+++ b/facets-dist/facets-jupyter.html
@@ -22026,6 +22026,7 @@ if("exit"===b&&""!==this.animationExit)return this.animationExit;if(this.animati
         font-size: 14px;
       }
       .legend .color iron-icon {
+        display: block;
         --iron-icon-width: 16px;
         --iron-icon-height: 16px;
         margin: 0 2px;
@@ -22159,6 +22160,9 @@ Polymer({is:"facets-dive-legend",properties:{colorBy:{type:String,value:"",obser
         margin: 4px 8px;
         min-width: 0;
         padding: 8px;
+      }
+      .zoom-controls iron-icon {
+        display: block;
       }
       facets-dive-info-card {
         background: #fff8f4;

--- a/facets_dive/components/facets_dive/facets-dive.html
+++ b/facets_dive/components/facets_dive/facets-dive.html
@@ -85,6 +85,9 @@ limitations under the License.
         min-width: 0;
         padding: 8px;
       }
+      .zoom-controls iron-icon {
+        display: block;
+      }
       facets-dive-info-card {
         background: #fff8f4;
         border-left: 1px solid #c6c6c6;

--- a/facets_dive/components/facets_dive_legend/facets-dive-legend.html
+++ b/facets_dive/components/facets_dive_legend/facets-dive-legend.html
@@ -84,6 +84,7 @@ limitations under the License.
         font-size: 14px;
       }
       .legend .color iron-icon {
+        display: block;
         --iron-icon-width: 16px;
         --iron-icon-height: 16px;
         margin: 0 2px;


### PR DESCRIPTION
Not 100% sure on the root cause, but I suspect it has to do with the way that the WebComponents polyfill works when encountering a previously cached `<link>` tag.

Setting the `display` style of the button icons explicitly to `block` fixes the bugs as reported.