### PR TITLE
Reserve tag number 10 and 11 in CommonStatistics proto

### DIFF
--- a/facets_overview/proto/feature_statistics.proto
+++ b/facets_overview/proto/feature_statistics.proto
@@ -240,6 +240,7 @@ message CommonStatistics {
   // the length of the feature list for this feature in an example (where each
   // feature list can contain multiple values).
   Histogram feature_list_length_histogram = 9;
+  reserved 10, 11;
 }
 
 // The data used to create a histogram of a numeric feature for a dataset.


### PR DESCRIPTION
To make sure CommonStatistics proto in [TFMD](https://github.com/tensorflow/metadata) are wire-compatible.