### PR TITLE
Fix Overview custom stats text cutoff

### DIFF
--- a/facets_overview/components/facets_overview_row_stats/facets-overview-row-stats.html
+++ b/facets_overview/components/facets_overview_row_stats/facets-overview-row-stats.html
@@ -46,7 +46,8 @@ limitations under the License.
       .data-custom {
         min-width: 150px;
         max-width: 150px;
-        white-space: pre;;
+        white-space: normal;
+        overflow-wrap: break-word;
       }
       #legend-box {
         width: 6px;

--- a/facets_overview/functional_tests/simple/simple_test.ts
+++ b/facets_overview/functional_tests/simple/simple_test.ts
@@ -89,7 +89,7 @@ function create(): DatasetFeatureStatisticsList {
   ]);
   featureStats = stats.getFeaturesList()[0];
   const customStats = [th.makeCustomStatistic('customHist', customHist),
-                       th.makeCustomStatistic('customNum', 13.1),
+                       th.makeCustomStatistic('customNum-reallylongname_testingoverflow', 13.1),
                        th.makeCustomStatistic('customRankHist', customRankHist),
                        th.makeCustomStatistic('customStr', 'cust')];
   featureStats.setCustomStatsList(customStats);


### PR DESCRIPTION
As per #240, long-titled custom stats were having their values cut off in Facets Overview, so they couldn't be viewed.

This fixes the issue by having the text wrap to be fully visible.