### PR TITLE
Fix bug with custom stats layout

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,16 @@
+## Building facets-overview compressed visualizations
+```
+npm install crisper terser polymer-bundler
+```
+
+```
+bazel build facets:facets-overview_jupyter
+```
+```
+cd bazel-bin/facets
+crisper -s facets-overview-jupyter.html -h facets-overview-jupyter-split.html -j facets-js.js
+terser --compress --comments -- facets-js.js > facets-js-terse.js
+cp facets-js-terse.js facets-js.js
+polymer-bundler --inline-scripts facets-overview-jupyter-split.html --out-file facets-overview-jupyter-split-bundled.html
+gzip -c facets-overview-jupyter-split-bundled.html > facets-overview-jupyter-split-bundled.html.gz
+```

--- a/facets/BUILD
+++ b/facets/BUILD
@@ -45,6 +45,33 @@ genrule(
 )
 
 tf_web_library(
+    name = "visualizations-overview",
+    srcs = [
+        "visualizations-overview.html",
+    ],
+    path = "/facets",
+    deps = [
+        "//facets_overview/components/facets_overview",
+        "@org_tensorflow_tensorboard//tensorboard/components/tf_imports:polymer",
+    ],
+)
+
+tensorboard_html_binary(
+    name = "facets-overview",
+    compile = True,
+    input_path = "/facets/visualizations-overview.html",
+    output_path = "/all/visualizations-overview.html",
+    deps = [":visualizations-overview"],
+)
+
+genrule(
+    name = "facets-overview_jupyter",
+    srcs = [":facets-overview"],
+    outs = ["facets-overview-jupyter.html"],
+    cmd = "sed 's|<!doctype html>|<!doctype html><script>define=undefined</script>|' $(location :facets-overview) > $@",
+)
+
+tf_web_library(
     name = "colab",
     srcs = [
         "colab.html",

--- a/facets/visualizations-overview.html
+++ b/facets/visualizations-overview.html
@@ -1,0 +1,2 @@
+<link rel="import" href="../../tf-imports/polymer.html">
+<link rel="import" href="../facets-overview/components/facets-overview/facets-overview.html">

--- a/facets_overview/components/facets_overview_row_stats/facets-overview-row-stats.html
+++ b/facets_overview/components/facets_overview_row_stats/facets-overview-row-stats.html
@@ -46,7 +46,7 @@ limitations under the License.
       .data-custom {
         min-width: 150px;
         max-width: 150px;
-        white-space: normal;
+        white-space: pre-wrap;
         overflow-wrap: break-word;
       }
       #legend-box {

--- a/facets_overview/functional_tests/simple/simple_test.ts
+++ b/facets_overview/functional_tests/simple/simple_test.ts
@@ -91,7 +91,10 @@ function create(): DatasetFeatureStatisticsList {
   const customStats = [th.makeCustomStatistic('customHist', customHist),
                        th.makeCustomStatistic('customNum-reallylongname_testingoverflow', 13.1),
                        th.makeCustomStatistic('customRankHist', customRankHist),
-                       th.makeCustomStatistic('customStr', 'cust')];
+                       th.makeCustomStatistic('customStr', 'cust'),
+                       th.makeCustomStatistic('cStr2', '2021-07-01'),
+                       th.makeCustomStatistic('cStr3', '2021-07-02')
+                      ];
   featureStats.setCustomStatsList(customStats);
   stats.setName('eval');
   data.getDatasetsList().push(stats);


### PR DESCRIPTION
Previously custom stats would word wrap strangely.

Before:

<img width="1066" alt="Screen Shot 2021-08-16 at 2 29 26 PM" src="https://user-images.githubusercontent.com/2577963/129635157-c12ed6de-3225-4970-a9db-fddccdbdfbeb.png">

After:

<img width="1065" alt="Screen Shot 2021-08-16 at 2 32 14 PM" src="https://user-images.githubusercontent.com/2577963/129635176-c137be1e-0cec-431a-a7a7-46d7efba11bb.png">

Testing:

bazel run //facets_overview/functional_tests/simple:devserver
click on index.html