### PR TITLE
replace deprecated numpy.asscalar

### DIFF
--- a/facets_overview/facets_overview/base_generic_feature_statistics_generator.py
+++ b/facets_overview/facets_overview/base_generic_feature_statistics_generator.py
@@ -208,11 +208,11 @@ class BaseGenericFeatureStatisticsGenerator(object):
             commonstats = featstats.common_stats
             if has_data:
               nums = value['vals']
-              featstats.std_dev = np.asscalar(np.std(nums))
-              featstats.mean = np.asscalar(np.mean(nums))
-              featstats.min = np.asscalar(np.min(nums))
-              featstats.max = np.asscalar(np.max(nums))
-              featstats.median = np.asscalar(np.median(nums))
+              featstats.std_dev = np.std(nums).item()
+              featstats.mean = np.mean(nums).item()
+              featstats.min = np.min(nums).item()
+              featstats.max = np.max(nums).item()
+              featstats.median = np.median(nums).item()
               featstats.num_zeros = len(nums) - np.count_nonzero(nums)
 
               nums = np.array(nums)

--- a/facets_overview/python/base_generic_feature_statistics_generator.py
+++ b/facets_overview/python/base_generic_feature_statistics_generator.py
@@ -213,11 +213,11 @@ class BaseGenericFeatureStatisticsGenerator(object):
             commonstats = featstats.common_stats
             if has_data:
               nums = value['vals']
-              featstats.std_dev = np.asscalar(np.std(nums))
-              featstats.mean = np.asscalar(np.mean(nums))
-              featstats.min = np.asscalar(np.min(nums))
-              featstats.max = np.asscalar(np.max(nums))
-              featstats.median = np.asscalar(np.median(nums))
+              featstats.std_dev = np.std(nums).item()
+              featstats.mean = np.mean(nums).item()
+              featstats.min = np.min(nums).item()
+              featstats.max = np.max(nums).item()
+              featstats.median = np.median(nums).item()
               featstats.num_zeros = len(nums) - np.count_nonzero(nums)
 
               nums = np.array(nums)


### PR DESCRIPTION
`numpy.asscalar` has been deprecated since 1.16 [1], and was removed in numpy 1.23.0 [2].

This PR lets facets-overview be used with numpy versions >= 1.23. 
facets-overview breaking on numpy > 1.22 is causing test failures in my attempt to allow apache-beam to use numpy >1.22: https://github.com/apache/beam/pull/25003#issuecomment-1382403867

Thanks!

[1] asscalar deprecated https://numpy.org/doc/1.22/reference/generated/numpy.asscalar.html
[2] removed in 1.23.0 https://numpy.org/doc/stable/release/1.23.0-notes.html#expired-deprecations