### PR TITLE
remove deprecated numpy type aliases

### DIFF
--- a/facets_overview/facets_overview/base_generic_feature_statistics_generator.py
+++ b/facets_overview/facets_overview/base_generic_feature_statistics_generator.py
@@ -65,7 +65,7 @@ class BaseGenericFeatureStatisticsGenerator(object):
     """Converts a Numpy dtype to the FeatureNameStatistics.Type proto enum."""
     if dtype.char in np.typecodes['AllFloat']:
       return self.fs_proto.FLOAT
-    elif (dtype.char in np.typecodes['AllInteger'] or dtype == np.bool or
+    elif (dtype.char in np.typecodes['AllInteger'] or dtype == bool or
           np.issubdtype(dtype, np.datetime64) or
           np.issubdtype(dtype, np.timedelta64)):
       return self.fs_proto.INT

--- a/facets_overview/facets_overview/generic_feature_statistics_generator_test.py
+++ b/facets_overview/facets_overview/generic_feature_statistics_generator_test.py
@@ -79,7 +79,7 @@ class GenericFeatureStatisticsGeneratorTest(googletest.TestCase):
                      self.gfsg.DtypeToType(np.dtype(np.int32)))
     # Boolean and time types treated as int
     self.assertEqual(self.gfsg.fs_proto.INT,
-                     self.gfsg.DtypeToType(np.dtype(np.bool)))
+                     self.gfsg.DtypeToType(np.dtype(bool)))
     self.assertEqual(self.gfsg.fs_proto.INT,
                      self.gfsg.DtypeToType(np.dtype(np.datetime64)))
     self.assertEqual(self.gfsg.fs_proto.INT,
@@ -87,7 +87,7 @@ class GenericFeatureStatisticsGeneratorTest(googletest.TestCase):
     self.assertEqual(self.gfsg.fs_proto.FLOAT,
                      self.gfsg.DtypeToType(np.dtype(np.float32)))
     self.assertEqual(self.gfsg.fs_proto.STRING,
-                     self.gfsg.DtypeToType(np.dtype(np.str)))
+                     self.gfsg.DtypeToType(np.dtype(str)))
     # Unsupported types treated as string for now
     self.assertEqual(self.gfsg.fs_proto.STRING,
                      self.gfsg.DtypeToType(np.dtype(np.void)))

--- a/facets_overview/python/base_generic_feature_statistics_generator.py
+++ b/facets_overview/python/base_generic_feature_statistics_generator.py
@@ -70,7 +70,7 @@ class BaseGenericFeatureStatisticsGenerator(object):
     """Converts a Numpy dtype to the FeatureNameStatistics.Type proto enum."""
     if dtype.char in np.typecodes['AllFloat']:
       return self.fs_proto.FLOAT
-    elif (dtype.char in np.typecodes['AllInteger'] or dtype == np.bool or
+    elif (dtype.char in np.typecodes['AllInteger'] or dtype == bool or
           np.issubdtype(dtype, np.datetime64) or
           np.issubdtype(dtype, np.timedelta64)):
       return self.fs_proto.INT

--- a/facets_overview/python/generic_feature_statistics_generator_test.py
+++ b/facets_overview/python/generic_feature_statistics_generator_test.py
@@ -79,7 +79,7 @@ class GenericFeatureStatisticsGeneratorTest(googletest.TestCase):
                      self.gfsg.DtypeToType(np.dtype(np.int32)))
     # Boolean and time types treated as int
     self.assertEqual(self.gfsg.fs_proto.INT,
-                     self.gfsg.DtypeToType(np.dtype(np.bool)))
+                     self.gfsg.DtypeToType(np.dtype(bool)))
     self.assertEqual(self.gfsg.fs_proto.INT,
                      self.gfsg.DtypeToType(np.dtype(np.datetime64)))
     self.assertEqual(self.gfsg.fs_proto.INT,
@@ -87,7 +87,7 @@ class GenericFeatureStatisticsGeneratorTest(googletest.TestCase):
     self.assertEqual(self.gfsg.fs_proto.FLOAT,
                      self.gfsg.DtypeToType(np.dtype(np.float32)))
     self.assertEqual(self.gfsg.fs_proto.STRING,
-                     self.gfsg.DtypeToType(np.dtype(np.str)))
+                     self.gfsg.DtypeToType(np.dtype(str)))
     # Unsupported types treated as string for now
     self.assertEqual(self.gfsg.fs_proto.STRING,
                      self.gfsg.DtypeToType(np.dtype(np.void)))


### PR DESCRIPTION
NumPy 1.20 deprecated the type aliases `np.bool` and `np.str`. As of NumPy 1.24.3, these aliases have been removed entirely, as seen below:
```
Python 3.9.15 (main, Nov 10 2022, 15:40:56) 
[GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import numpy
>>> numpy.bool
<stdin>:1: FutureWarning: In the future `np.bool` will be defined as the corresponding NumPy scalar.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/archbtw/.pyenv/versions/3.9.15/lib/python3.9/site-packages/numpy/__init__.py", line 305, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'bool'.
`np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

This change replaces the removed NumPy type aliases with their modern equivalents.